### PR TITLE
fix:TUN

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,8 +64,24 @@ def _run_silent_command(command: list[str], timeout: int = 5):
 
 
 def force_evict_zombie_backends():
-    """启动前只清理上轮崩溃遗留的 sing-box 后端进程。"""
+    """启动前清理上轮崩溃遗留的 sing-box 后端进程、TUN 虚拟适配器及残留路由。
+
+    清理顺序：进程 → 适配器 → 路由。
+    """
     _run_silent_command(["taskkill", "/F", "/IM", "sing-box.exe", "/T"], timeout=3)
+    _run_silent_command([
+        "powershell", "-NoProfile", "-Command",
+        "$targets = @(Get-PnpDevice -Class Net -ErrorAction SilentlyContinue | "
+        "Where-Object { $_.InstanceId -like '*WINTUN*' }); "
+        "if ($targets.Count -gt 0) { "
+        "$targets | Disable-PnpDevice -Confirm:$false -ErrorAction SilentlyContinue; "
+        "Start-Sleep -Milliseconds 800; "
+        "foreach ($d in $targets) { pnputil /remove-device $d.InstanceId 2>&1 | Out-Null } }",
+    ], timeout=10)
+    # 清理崩溃后残留的 TUN 默认路由（172.19.0.1 是 sing-box 配置中硬编码的 TUN 网关）
+    _run_silent_command(
+        ["route", "delete", "0.0.0.0", "mask", "0.0.0.0", "172.19.0.1"], timeout=5
+    )
 
 
 from utils.network_utils import is_admin

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1365,6 +1365,14 @@ def create_main_window():
                         startupinfo=startupinfo,
                         creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000),
                     )
+                    # 防御式清理：正常路径 force_kill 已删路由，此处兜底异常路径
+                    subprocess.run(
+                        ["route", "delete", "0.0.0.0", "mask", "0.0.0.0", "172.19.0.1"],
+                        capture_output=True,
+                        timeout=5,
+                        startupinfo=startupinfo,
+                        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000),
+                    )
                 except Exception:
                     pass
 

--- a/utils/autostart.py
+++ b/utils/autostart.py
@@ -23,7 +23,10 @@ def get_executable_path() -> str:
     """Return the executable command used by the scheduled task."""
     is_frozen = getattr(sys, "frozen", False) or ("__compiled__" in globals())
     if is_frozen:
-        return os.path.abspath(sys.executable or sys.argv[0])
+        # Nuitka onefile 会把自身解压到 %TEMP%\onefile_<pid>_<random>\ 然后运行，
+        # sys.executable 指向临时目录里的 python.exe，退出后即被删除。
+        # 必须用 sys.argv[0] 获取用户实际启动的原始 EXE 路径。
+        return os.path.abspath(sys.argv[0])
 
     script_path = Path(__file__).resolve().parents[1] / "main.py"
     return f'"{os.path.abspath(sys.executable)}" "{script_path}"'

--- a/utils/singbox_config.py
+++ b/utils/singbox_config.py
@@ -139,7 +139,7 @@ def build_config(
         },
         {"port": [53], "action": "hijack-dns"},
         {"protocol": ["dns"], "action": "hijack-dns"},
-        {"network": ["udp"], "action": "reject", "method": "default", "no_drop": True},
+        {"network": ["udp"], "action": "route", "outbound": "direct"},
     ])
     route_rules = defensive_route_rules + user_route_rules
 
@@ -191,7 +191,7 @@ def build_config(
                 "tag": "tun-in",
                 "interface_name": tun_name,
                 "address": ["172.19.0.1/30"],
-                "mtu": 9000,
+                "mtu": 1492,
                 "auto_route": True,
                 "strict_route": True,
                 "stack": "system",

--- a/utils/tun_manager.py
+++ b/utils/tun_manager.py
@@ -152,6 +152,7 @@ class TunManager(QThread):
 
         work_dir = os.path.dirname(exe)
         await self._preflight_cleanup_singbox()
+        await self._cleanup_tun_adapter()
         try:
             self._proc = await asyncio.create_subprocess_exec(
                 exe, "run", "-c", self._config_path,
@@ -281,6 +282,53 @@ class TunManager(QThread):
         except Exception as e:
             self.log_signal.emit(f"[TUN] 启动前清理 sing-box 残留进程异常: {e}")
 
+    async def _cleanup_tun_adapter(self):
+        """删除残留的 HypoMux-Tun 虚拟适配器（上次崩溃/强杀遗留的僵尸设备）。
+
+        匹配 InstanceId *WINTUN* → Disable-PnpDevice → pnputil /remove-device。
+        pnputil 是 Windows 内置工具始终可用，不依赖 PowerShell Remove-* cmdlet。
+        """
+        _PS_CLEANUP_CMD = (
+            "$targets = @(Get-PnpDevice -Class Net -ErrorAction SilentlyContinue | "
+            "Where-Object { $_.InstanceId -like '*WINTUN*' }); "
+            "if ($targets.Count -gt 0) { "
+            "Write-Output ('发现 ' + $targets.Count + ' 个残留 wintun 设备: ' + "
+            "[string]::Join(', ', ($targets | ForEach-Object { $_.FriendlyName }))); "
+            "$targets | Disable-PnpDevice -Confirm:$false -ErrorAction SilentlyContinue; "
+            "Start-Sleep -Milliseconds 800; "
+            "foreach ($d in $targets) { pnputil /remove-device $d.InstanceId 2>&1 | Out-Null } "
+            "}"
+        )
+        try:
+            si = None
+            if hasattr(subprocess, "STARTUPINFO"):
+                si = subprocess.STARTUPINFO()
+                si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                si.wShowWindow = 0
+            proc = await asyncio.create_subprocess_exec(
+                "powershell", "-NoProfile", "-Command", _PS_CLEANUP_CMD,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                startupinfo=si,
+                creationflags=_CREATE_NO_WINDOW,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=12)
+            # 始终输出诊断信息（无论 returncode，诊断信息在 stdout 中）
+            for raw in (stdout, stderr):
+                if not raw:
+                    continue
+                text = self._decode_process_output(raw).strip()
+                if text:
+                    self.log_signal.emit(f"[TUN] 虚拟网卡适配器清理: {text}")
+            # 等待 Windows 完成异步设备移除
+            await asyncio.sleep(0.5)
+        except asyncio.TimeoutError:
+            self.log_signal.emit("[TUN] 虚拟网卡适配器清理超时，继续尝试拉起内核")
+        except FileNotFoundError:
+            self.log_signal.emit("[TUN] 未找到 PowerShell，跳过适配器清理")
+        except Exception as e:
+            self.log_signal.emit(f"[TUN] 虚拟网卡适配器清理异常: {e}")
+
     @staticmethod
     def _decode_process_output(raw: bytes) -> str:
         """解码 Windows 子进程输出，兼容 UTF-8 与系统 OEM 代码页。"""
@@ -374,3 +422,32 @@ class TunManager(QThread):
         """同步兜底强杀：用于 closeEvent 等必须立即清理的场景。"""
         self._taskkill_singbox()
         self._cleanup_routes()
+        self._force_cleanup_tun_adapter()
+
+    def _force_cleanup_tun_adapter(self):
+        """同步删除残留 HypoMux-Tun 适配器（force_kill 兜底路径）。
+
+        匹配 InstanceId *WINTUN* → Disable-PnpDevice → pnputil /remove-device。
+        """
+        try:
+            si = None
+            if hasattr(subprocess, "STARTUPINFO"):
+                si = subprocess.STARTUPINFO()
+                si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                si.wShowWindow = 0
+            subprocess.run(
+                [
+                    "powershell", "-NoProfile", "-Command",
+                    "$targets = @(Get-PnpDevice -Class Net -ErrorAction SilentlyContinue | "
+                    "Where-Object { $_.InstanceId -like '*WINTUN*' }); "
+                    "if ($targets.Count -gt 0) { "
+                    "$targets | Disable-PnpDevice -Confirm:$false -ErrorAction SilentlyContinue; "
+                    "Start-Sleep -Milliseconds 800; "
+                    "foreach ($d in $targets) { pnputil /remove-device $d.InstanceId 2>&1 | Out-Null } }",
+                ],
+                capture_output=True, timeout=10,
+                startupinfo=si,
+                creationflags=_CREATE_NO_WINDOW,
+            )
+        except Exception:
+            pass


### PR DESCRIPTION
修复后游戏/视频等 UDP 流量在 TUN 模式下可正常通信 
- 将UDP默认策略从 reject 改为 route（走 direct 直连出站）
- TUN MTU 从 9000 调整为 1492（PPPoE 兼容）

修复后开启TUN不会出现异常： INFO [TUN] sing-box 内核意外退出 (code=1)
-  启动前清理：force_evict_zombie_backends 新增 WINTUN 设备移除和残留默认路由清理
- TunManager 异步预检：_cleanup_tun_adapter 在拉起 sing-box 前删除僵尸虚拟网卡
- TunManager 同步兜底：force_kill 新增 _force_cleanup_tun_adapter 确保关闭时清理
- 关闭事件防御：TUN 停止异常路径兜底清理 172.19.0.1 残留路由
- 修复 Nuitka onefile 模式下自启动路径指向临时目录的问题（改用 sys.argv[0]） 