### PR TITLE
fix: surface cleanup errors, bound pipe handshake and core termination

### DIFF
--- a/desktop/internal/engineclient/privileged_windows.go
+++ b/desktop/internal/engineclient/privileged_windows.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -27,6 +28,9 @@ const (
 	sessionReadyKind       = "hypomux.host.ready"
 	seeMaskNoCloseProcess  = 0x00000040
 	maxSessionMessageBytes = 4096
+	// coreTerminateWait bounds how long a failed launch waits for the core
+	// process to exit before giving up (see privilegedLauncher.Launch).
+	coreTerminateWait = 5 * time.Second
 )
 
 var ErrElevationCancelled = errors.New("用户取消了管理员权限请求")
@@ -101,8 +105,12 @@ func (privilegedLauncher) Launch(ctx context.Context, path string) (*coreSession
 	}
 	connection, err := pipe.accept(ctx, process.pid)
 	if err != nil {
+		// The desktop cannot terminate an elevated process (ACCESS_DENIED) and
+		// a wedged core may never exit on its own. Never wait indefinitely
+		// here: the startGate slot would stay occupied and every future Ensure
+		// call would time out until the desktop restarts.
 		_ = process.Kill()
-		_ = process.Wait()
+		_ = process.waitTimeout(coreTerminateWait)
 		return nil, fmt.Errorf("验证高权限核心通信失败：%w", err)
 	}
 	return &coreSession{
@@ -363,9 +371,37 @@ func (p *windowsCoreProcess) Kill() error {
 	}
 	err := windows.TerminateProcess(p.handle, 1)
 	if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
-		return nil
+		// The desktop UI runs unelevated and can never terminate an elevated
+		// core; pretending success let callers wait forever for a process that
+		// is still running.
+		return fmt.Errorf("终止管理员核心：%w", err)
 	}
 	return err
+}
+
+// waitTimeout waits for the process to exit up to timeout, then releases the
+// handle. It is used on launch-failure paths where the caller gives up on the
+// process; the session watcher keeps using the unbounded Wait instead.
+func (p *windowsCoreProcess) waitTimeout(timeout time.Duration) error {
+	p.mu.Lock()
+	handle := p.handle
+	p.mu.Unlock()
+	if handle == 0 || handle == windows.InvalidHandle {
+		return nil
+	}
+	event, err := windows.WaitForSingleObject(handle, uint32(timeout/time.Millisecond))
+	p.release()
+	if err != nil {
+		return err
+	}
+	switch event {
+	case windows.WAIT_OBJECT_0:
+		return nil
+	case uint32(windows.WAIT_TIMEOUT):
+		return fmt.Errorf("等待管理员核心退出超时（%v）", timeout)
+	default:
+		return fmt.Errorf("等待管理员核心退出返回状态 0x%X", event)
+	}
 }
 
 func (p *windowsCoreProcess) PID() int {

--- a/desktop/internal/startup/cleanup_windows.go
+++ b/desktop/internal/startup/cleanup_windows.go
@@ -50,15 +50,24 @@ func killProcess(ctx context.Context, processName string) error {
 	// Suppress window creation on Windows
 	hideWindow(cmd)
 
-	// taskkill returns error if process not found, which is acceptable
-	output, _ := cmd.CombinedOutput()
-
-	// Check if process was not found (acceptable) vs actual error
-	outputStr := string(output)
-	if strings.Contains(outputStr, "not found") || strings.Contains(outputStr, "未找到") {
-		return nil
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		outputStr := string(output)
+		// taskkill reports "no matching task" via exit code 128 regardless of
+		// UI language; text matching alone would miss localized variants
+		// (e.g. zh-CN prints the message in CP936). A missing process is the
+		// expected steady state and must not surface as a startup error.
+		var exitErr *exec.ExitError
+		if (errors.As(err, &exitErr) && exitErr.ExitCode() == 128) ||
+			strings.Contains(outputStr, "not found") {
+			return nil
+		}
+		if strings.TrimSpace(outputStr) == "" {
+			// A context deadline can kill taskkill before it writes anything.
+			outputStr = err.Error()
+		}
+		return fmt.Errorf("kill %s: %s", processName, strings.TrimSpace(outputStr))
 	}
-
 	return nil
 }
 

--- a/engine/cmd/hypomux-engine/pipe_windows.go
+++ b/engine/cmd/hypomux-engine/pipe_windows.go
@@ -20,6 +20,7 @@ const (
 	pipeSessionAuthKind   = "hypomux.core.authenticate"
 	pipeSessionReadyKind  = "hypomux.host.ready"
 	maxPipeSessionMessage = 4096
+	pipeAuthTimeout       = 10 * time.Second
 )
 
 type pipeAuthMessage struct {
@@ -100,15 +101,28 @@ func connectAuthenticatedPipe(
 		_ = connection.Close()
 		return nil, err
 	}
-	reader := bufio.NewReaderSize(connection, maxPipeSessionMessage)
-	line, err := reader.ReadBytes('\n')
-	if err != nil {
+	// The host is trusted to reply quickly; without a deadline a silent peer
+	// would leave serve-pipe hanging forever.
+	if err := connection.SetReadDeadline(time.Now().Add(pipeAuthTimeout)); err != nil {
 		_ = connection.Close()
 		return nil, err
 	}
-	if len(line) > maxPipeSessionMessage {
+	reader := bufio.NewReaderSize(connection, maxPipeSessionMessage)
+	// ReadSlice caps the line at the buffer size: an overlong line without a
+	// newline returns ErrBufferFull instead of growing an unbounded buffer.
+	line, err := reader.ReadSlice('\n')
+	if err != nil {
 		_ = connection.Close()
-		return nil, errors.New("host authentication response is too large")
+		if errors.Is(err, bufio.ErrBufferFull) {
+			return nil, errors.New("host authentication response is too large")
+		}
+		return nil, err
+	}
+	// Clear the handshake deadline: the same connection carries the long-lived
+	// session afterwards and must not be bound by the auth timeout.
+	if err := connection.SetReadDeadline(time.Time{}); err != nil {
+		_ = connection.Close()
+		return nil, err
 	}
 	var ready pipeReadyMessage
 	if err := json.Unmarshal(line, &ready); err != nil {


### PR DESCRIPTION
## 概述

来自 #50 的 review 修复（健壮性部分，3 个独立 commit）。

### Commit 1: `fix(startup): surface taskkill failures during zombie cleanup`

**问题**：`killProcess` 无条件吞掉所有 taskkill 错误——提权僵尸引擎因权限不足清理失败时**无任何日志**，"启动清理"形同虚设。

**修复**：仅"进程不存在"视为正常（用 taskkill 退出码 128 判断，**语言无关**——中文系统输出为 CP936 编码，文本匹配不可靠）；其余错误向上传播到启动日志；ctx 超时杀死 taskkill 导致输出为空时，保留底层错误信息。

**验证边界**：taskkill 退出码 128 已在本机实测确认。

### Commit 2: `fix(engine): bound pipe authentication handshake with a timeout`

**问题**：`serve-pipe` 认证读取无 deadline，主机不响应时进程永久挂起；且超长无换行行在 `ReadBytes` 中无界增长后才做长度检查。

**修复**：10s 读超时 + `ReadSlice` 在 4 KiB 缓冲处拒绝超长行（`ErrBufferFull`，零内存放大）；握手后清除 deadline，不约束后续长会话。

### Commit 3: `fix(engineclient): stop pretending elevated core termination succeeds`

**问题**：桌面对提权核心 `TerminateProcess` 必然返回 ACCESS_DENIED，`Kill()` 却把它转成成功；随后启动失败路径 `WaitForSingleObject(INFINITE)` 永久阻塞——若提权核心僵死，startGate 槽位被占，**之后所有 Ensure 调用超时直到重启桌面**。

**修复**：`Kill()` 如实返回 ACCESS_DENIED 错误；失败路径改用有界 `waitTimeout(5s)`（等待后释放句柄），不再无限期阻塞。

**验证边界**：ACCESS_DENIED 提权路径未能本地复现完整提权会话，为逻辑审查 + 现有测试兜底。

## 验证

- `go test ./engine/...`、`go test ./desktop/...`、`go vet` 全部通过
- D3 的 taskkill 行为本机实测（退出码 128）；D4 的提权路径验证边界如上如实说明

Refs #50
