### PR TITLE
fix: correct WFP DNS exemption byte order and always verify installer digest

### DIFF
--- a/desktop/internal/services/updater.go
+++ b/desktop/internal/services/updater.go
@@ -324,8 +324,7 @@ func (s *UpdaterService) Download(release ReleaseInfo) (string, error) {
 		_ = os.Remove(partial)
 		return "", fmt.Errorf("安装包大小校验失败（预期 %d，实际 %d）", release.InstallerSize, written)
 	}
-	if expected := strings.TrimPrefix(strings.ToLower(release.InstallerDigest), "sha256:"); expected != "" &&
-		expected != strings.ToLower(release.InstallerDigest) {
+	if expected := strings.TrimPrefix(strings.ToLower(release.InstallerDigest), "sha256:"); expected != "" {
 		if actual := hex.EncodeToString(hash.Sum(nil)); actual != expected {
 			_ = os.Remove(partial)
 			return "", errors.New("安装包 SHA-256 校验失败")

--- a/desktop/internal/services/updater_test.go
+++ b/desktop/internal/services/updater_test.go
@@ -86,6 +86,32 @@ func TestUpdaterFallsBackToReleaseFeedWhenAPIIsRateLimited(t *testing.T) {
 	}
 }
 
+func TestUpdaterRejectsMismatchedDigestWithoutPrefix(t *testing.T) {
+	const payload = "hypomux-installer-payload"
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		response := &http.Response{
+			Request: request, Header: make(http.Header), StatusCode: http.StatusOK,
+			Body: io.NopCloser(strings.NewReader(payload)),
+		}
+		response.ContentLength = int64(len(payload))
+		return response, nil
+	})}
+	service := NewUpdaterService()
+	service.client = client
+
+	// Digest intentionally carries no "sha256:" prefix while being wrong:
+	// verification must still run and fail the download.
+	_, err := service.Download(ReleaseInfo{
+		InstallerName:   "HypoMux_Setup_2.5.5.exe",
+		InstallerSize:   int64(len(payload)),
+		InstallerURL:    "https://github.com/Hypostasis-Cat/HypoMux/releases/download/v2.5.5/HypoMux_Setup_2.5.5.exe",
+		InstallerDigest: strings.Repeat("0", 64),
+	})
+	if err == nil {
+		t.Fatal("Download accepted a mismatched digest; SHA-256 verification was skipped")
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {

--- a/engine/internal/wfp/dns_exemption_windows.go
+++ b/engine/internal/wfp/dns_exemption_windows.go
@@ -280,8 +280,11 @@ func buildRules(adapters []Adapter) []dnsRule {
 			}
 			seen[key] = struct{}{}
 			result = append(result, dnsRule{
-				adapter:  adapter.Name,
-				sourceIP: binary.LittleEndian.Uint32(ip),
+				adapter: adapter.Name,
+				// WFP requires FWPM_CONDITION_IP_LOCAL_ADDRESS in host byte order
+				// (ntohl of the network-order bytes); BigEndian.Uint32 yields that
+				// value on any machine. Do NOT switch back to LittleEndian.
+				sourceIP: binary.BigEndian.Uint32(ip),
 				ifIndex:  adapter.IfIndex,
 				protocol: protocol,
 			})

--- a/engine/internal/wfp/dns_exemption_windows_test.go
+++ b/engine/internal/wfp/dns_exemption_windows_test.go
@@ -38,3 +38,18 @@ func TestBuildDNSRulesIsNarrowAndDeduplicated(t *testing.T) {
 		t.Fatalf("protocols = %#v", rules)
 	}
 }
+
+func TestBuildDNSRulesUsesHostOrderIP(t *testing.T) {
+	rules := buildRules([]Adapter{
+		{Name: "Ethernet", SourceIP: "192.168.10.24", IfIndex: 12},
+	})
+	if len(rules) == 0 {
+		t.Fatal("buildRules returned no rules")
+	}
+	// WFP expects FWPM_CONDITION_IP_LOCAL_ADDRESS values in host byte order
+	// (ntohl of the network-order bytes), so 192.168.10.24 must be 0xC0A80A18.
+	const want = uint32(0xC0A80A18)
+	if rules[0].sourceIP != want {
+		t.Fatalf("sourceIP = 0x%08X, want 0x%08X (host byte order)", rules[0].sourceIP, want)
+	}
+}


### PR DESCRIPTION
## 概述

来自 #50 的 review 修复（正确性部分，2 个独立 commit）。

### Commit 1: `fix(wfp): use host byte order for DNS exemption source IP`

**问题**：`buildRules` 用 `binary.LittleEndian.Uint32` 生成 `FWPM_CONDITION_IP_LOCAL_ADDRESS` 条件值。WFP 过滤引擎要求该值为**主机字节序**——微软文档 [Populating Filter Conditions](https://learn.microsoft.com/en-us/windows/win32/fwp/populating-filter-conditions) 明确使用 `ntohl(*(ULONG*)addr)`。`LittleEndian.Uint32` 缺少字节交换（如 `192.168.10.24` → `0x180AA8C0` 而非 `0xC0A80A18`），地址条件永不匹配，**严格路由模式下 DNS 豁免静默失效**（过滤器正常添加但不命中）。

**修复**：改为 `binary.BigEndian.Uint32(ip)`（在小端 Windows 上等价 ntohl，且与机器字节序无关）。新增测试断言 `192.168.10.24 → 0xC0A80A18`，验证可捕获回归。

### Commit 2: `fix(updater): verify SHA-256 digest without sha256: prefix`

**问题**：`Download` 的校验条件 `expected != "" && expected != strings.ToLower(InstallerDigest)` 中，摘要不带 `sha256:` 前缀时第二个条件短路，**完整性校验被静默跳过**。

**修复**：任何非空摘要都执行 SHA-256 校验。新增测试 `TestUpdaterRejectsMismatchedDigestWithoutPrefix`（无前缀错误摘要必须校验失败）。

## 验证

- 两个修复均通过 TDD（RED → GREEN → mutation）
- `go test ./engine/...`、`go test ./desktop/...`、`go vet` 全部通过

Refs #50
