### PR TITLE
fix: serialize settings saves and bound DoH race concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,10 @@ jobs:
         shell: pwsh
         run: wails3 generate bindings -clean=true -ts -i
 
+      - name: Run frontend tests
+        shell: pwsh
+        run: pnpm --dir desktop/frontend test
+
       - name: Build frontend assets for Go validation
         shell: pwsh
         run: pnpm --dir desktop/frontend build

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build:dev": "tsc && vite build --minify false --mode development",
     "build": "tsc && vite build --mode production",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fluentui/react-components": "9.74.4",
@@ -23,6 +24,7 @@
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^6.0.0",
     "typescript": "^5.2.2",
-    "vite": "^8.0.5"
+    "vite": "^8.0.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -45,12 +45,36 @@ importers:
       vite:
         specifier: ^8.0.5
         version: 8.1.5
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.1.5)
 
 packages:
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@ctrl/tinycolor@3.6.1':
     resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
@@ -609,6 +633,16 @@ packages:
   '@griffel/style-types@1.4.2':
     resolution: {integrity: sha512-MsSghfpyxR2MpTrYdcCozISsSLkmFjNw94wNPi4bDBRLW8W43718W/ZjmUdVkoM0KXMtJPYuEkx8Mzibqb03qA==}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@napi-rs/wasm-runtime@1.2.0':
     resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
@@ -717,14 +751,23 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -774,14 +817,63 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@wailsio/runtime@3.0.0-alpha2.117':
     resolution: {integrity: sha512-RZr6cncIXjdTbn2IqJ6AZXPm9WooaZEsNlNfaUH+Ru/YlH5sKDDeRdWpbcvsgoMLh4AJ+O8aBzZEiTYWDipGxw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -797,6 +889,9 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -837,12 +932,22 @@ packages:
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -861,11 +966,18 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -888,6 +1000,21 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -975,6 +1102,16 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -1116,8 +1253,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1171,12 +1315,26 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -1190,12 +1348,27 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tabster@8.8.0:
     resolution: {integrity: sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1283,12 +1456,78 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
+  '@babel/helper-string-parser@7.29.7':
+    optional: true
+
+  '@babel/helper-validator-identifier@7.29.7':
+    optional: true
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+    optional: true
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+    optional: true
+
+  '@bcoe/v8-coverage@1.0.2':
+    optional: true
 
   '@ctrl/tinycolor@3.6.1': {}
 
@@ -2494,6 +2733,17 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@jridgewell/resolve-uri@3.1.2':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
+
   '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -2554,6 +2804,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
@@ -2563,9 +2815,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -2605,11 +2864,78 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5
 
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.1.5)
+    optional: true
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.1.5)':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@wailsio/runtime@3.0.0-alpha2.117': {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+    optional: true
 
   bail@2.0.2: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -2620,6 +2946,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -2649,9 +2977,17 @@ snapshots:
 
   embla-carousel@8.6.0: {}
 
+  es-module-lexer@2.3.1: {}
+
   escape-string-regexp@5.0.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -2660,6 +2996,9 @@ snapshots:
       picomatch: 4.0.5
 
   fsevents@2.3.3:
+    optional: true
+
+  has-flag@4.0.0:
     optional: true
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -2686,6 +3025,9 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
 
+  html-escaper@2.0.2:
+    optional: true
+
   html-url-attributes@3.0.1: {}
 
   inline-style-parser@0.2.7: {}
@@ -2702,6 +3044,25 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
+
+  istanbul-lib-coverage@3.2.2:
+    optional: true
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    optional: true
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    optional: true
+
+  js-tokens@10.0.0:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -2761,6 +3122,22 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+    optional: true
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+    optional: true
 
   markdown-table@3.0.4: {}
 
@@ -3112,6 +3489,8 @@ snapshots:
 
   nanoid@3.3.16: {}
 
+  obug@2.1.4: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -3121,6 +3500,8 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3225,9 +3606,18 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  semver@7.8.5:
+    optional: true
+
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stringify-entities@4.0.4:
     dependencies:
@@ -3244,15 +3634,26 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+    optional: true
+
   tabster@8.8.0:
     dependencies:
       keyborg: 2.14.1
       tslib: 2.8.1
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   trim-lines@3.0.1: {}
 
@@ -3318,5 +3719,37 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
+
+  vitest@4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.1.5):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5)
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.5
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   zwitch@2.0.4: {}

--- a/desktop/frontend/src/pages/SettingsPage.tsx
+++ b/desktop/frontend/src/pages/SettingsPage.tsx
@@ -32,6 +32,7 @@ import { GlassSurface } from "../components/material/GlassSurface";
 import { AppToaster } from "../components/AppToaster";
 import { desktopPlatform } from "../platform/desktop";
 import { appServices, type CompleteAppSettings, type ConfigMigrationStatus } from "../platform/services";
+import { SettingsSaveQueue } from "../platform/settingsQueue";
 import { accentColours } from "../theme/appearance.presets";
 import { useAppearance } from "../theme/appearance.store";
 import { backgroundService } from "../theme/background.service";
@@ -120,16 +121,29 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
   const { locale, setLocale, t } = useI18n();
   const text = (zh: string, en: string) => locale === "en" ? en : zh;
   const backgroundInput = useRef<HTMLInputElement>(null);
-  // Serialize settings persistence: concurrent saves would otherwise let an
-  // earlier response overwrite a newer optimistic value, silently dropping
-  // the user's latest change (and mixing full-replace updates with the
-  // partial SetAutostart/SetAutoStartEngine endpoints).
-  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  // Serialize settings persistence and track per-field ownership: concurrent
+  // saves would otherwise let an earlier response overwrite a newer optimistic
+  // value, and a failed operation's recovery must not overwrite a later
+  // operation's success (see settingsQueue).
+  const saveQueue = useRef(new SettingsSaveQueue()).current;
 
-  const enqueueSave = (operation: () => Promise<void>): Promise<void> => {
-    const next = saveQueueRef.current.then(operation);
-    saveQueueRef.current = next.catch(() => undefined);
-    return next;
+  const enqueueSave = <T,>(operation: () => Promise<T>, fields: string[] | null): Promise<T> =>
+    saveQueue.enqueue(operation, fields);
+
+  const applyAuthoritative = (authoritative: CompleteAppSettings) => {
+    setSettings((current) =>
+      saveQueue.mergeAuthoritative({ ...emptySettings, ...authoritative }, current),
+    );
+  };
+
+  const applyRecovery = (ownedFields: string[] | null, authoritative: CompleteAppSettings) => {
+    setSettings((current) =>
+      saveQueue.recoverAuthoritative(
+        ownedFields,
+        { ...emptySettings, ...authoritative },
+        current,
+      ),
+    );
   };
 
   const toasterId = useId("settings-toaster");
@@ -166,28 +180,28 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       .finally(() => setLoading(false));
   }, []);
 
-  const save = (next: CompleteAppSettings, success?: string): Promise<void> => {
+  const save = (next: CompleteAppSettings, success?: string, fields: string[] | null = null): Promise<void> => {
     setSettings(next);
     return enqueueSave(async () => {
       setSaving(true);
       try {
         const persisted = await appServices.settings.update(next);
-        setSettings((current) => ({ ...emptySettings, ...persisted, ...current }));
+        applyAuthoritative(persisted);
         setLocale(persisted.language);
         notify(t("infobar_success"), success ?? text("设置已保存", "Settings saved"));
       } catch (error) {
         const restored = await appServices.settings.get().catch(() => next);
-        setSettings({ ...emptySettings, ...restored });
+        applyRecovery(fields, restored);
         setLocale(restored.language);
         notify(text("保存失败", "Save failed"), String(error), "error");
       } finally {
         setSaving(false);
       }
-    });
+    }, fields);
   };
 
   const patchAndSave = (patch: Partial<CompleteAppSettings>, success?: string) =>
-    save({ ...settings, ...patch }, success);
+    save({ ...settings, ...patch }, success, Object.keys(patch));
 
   const setAutostart = (enabled: boolean): Promise<void> => {
     // Optimistically mirror the backend semantics: disabling autostart also
@@ -202,7 +216,7 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       setSaving(true);
       try {
         const persisted = await appServices.settings.setAutostart(enabled);
-        setSettings((current) => ({ ...emptySettings, ...persisted, ...current }));
+        applyAuthoritative(persisted);
         notify(
           enabled ? t("settings_autostart_on") : t("settings_autostart_off"),
           t("settings_autostart_hint"),
@@ -210,13 +224,13 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       } catch (error) {
         const restored = await appServices.settings.get().catch(() => null);
         if (restored) {
-          setSettings({ ...emptySettings, ...restored });
+          applyRecovery(["autostart", "auto_start_engine"], restored);
         }
         notify(t("settings_autostart_failed"), String(error), "error");
       } finally {
         setSaving(false);
       }
-    });
+    }, ["autostart", "auto_start_engine"]);
   };
 
   const setAutoStartEngine = (enabled: boolean): Promise<void> => {
@@ -225,7 +239,7 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       setSaving(true);
       try {
         const persisted = await appServices.settings.setAutoStartEngine(enabled);
-        setSettings((current) => ({ ...emptySettings, ...persisted, ...current }));
+        applyAuthoritative(persisted);
         notify(
           enabled ? t("settings_auto_start_engine_on") : t("settings_auto_start_engine_off"),
           t("settings_auto_start_engine_hint"),
@@ -233,13 +247,13 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       } catch (error) {
         const restored = await appServices.settings.get().catch(() => null);
         if (restored) {
-          setSettings({ ...emptySettings, ...restored });
+          applyRecovery(["auto_start_engine"], restored);
         }
         notify(t("settings_auto_start_engine_failed"), String(error), "error");
       } finally {
         setSaving(false);
       }
-    });
+    }, ["auto_start_engine"]);
   };
 
   const inspectWfp = async () => {
@@ -302,7 +316,7 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
         const next = migrationDialog === "migrate"
           ? await appServices.settings.migrateLegacy()
           : await appServices.settings.rollbackLegacy();
-        setSettings({ ...emptySettings, ...next });
+        applyAuthoritative(next);
         setLocale(next.language);
         setMigration(await appServices.settings.migrationStatus());
         notify(
@@ -320,7 +334,7 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       } finally {
         setSaving(false);
       }
-    });
+    }, null);
   };
 
   return (

--- a/desktop/frontend/src/pages/SettingsPage.tsx
+++ b/desktop/frontend/src/pages/SettingsPage.tsx
@@ -120,6 +120,17 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
   const { locale, setLocale, t } = useI18n();
   const text = (zh: string, en: string) => locale === "en" ? en : zh;
   const backgroundInput = useRef<HTMLInputElement>(null);
+  // Serialize settings persistence: concurrent saves would otherwise let an
+  // earlier response overwrite a newer optimistic value, silently dropping
+  // the user's latest change (and mixing full-replace updates with the
+  // partial SetAutostart/SetAutoStartEngine endpoints).
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+  const enqueueSave = (operation: () => Promise<void>): Promise<void> => {
+    const next = saveQueueRef.current.then(operation);
+    saveQueueRef.current = next.catch(() => undefined);
+    return next;
+  };
 
   const toasterId = useId("settings-toaster");
   const { dispatchToast } = useToastController(toasterId);
@@ -155,57 +166,80 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       .finally(() => setLoading(false));
   }, []);
 
-  const save = async (next: CompleteAppSettings, success?: string) => {
+  const save = (next: CompleteAppSettings, success?: string): Promise<void> => {
     setSettings(next);
-    setSaving(true);
-    try {
-      const persisted = await appServices.settings.update(next);
-      setSettings({ ...emptySettings, ...persisted });
-      setLocale(persisted.language);
-      notify(t("infobar_success"), success ?? text("设置已保存", "Settings saved"));
-    } catch (error) {
-      const restored = await appServices.settings.get().catch(() => settings);
-      setSettings({ ...emptySettings, ...restored });
-      setLocale(restored.language);
-      notify(text("保存失败", "Save failed"), String(error), "error");
-    } finally {
-      setSaving(false);
-    }
+    return enqueueSave(async () => {
+      setSaving(true);
+      try {
+        const persisted = await appServices.settings.update(next);
+        setSettings((current) => ({ ...emptySettings, ...persisted, ...current }));
+        setLocale(persisted.language);
+        notify(t("infobar_success"), success ?? text("设置已保存", "Settings saved"));
+      } catch (error) {
+        const restored = await appServices.settings.get().catch(() => next);
+        setSettings({ ...emptySettings, ...restored });
+        setLocale(restored.language);
+        notify(text("保存失败", "Save failed"), String(error), "error");
+      } finally {
+        setSaving(false);
+      }
+    });
   };
 
   const patchAndSave = (patch: Partial<CompleteAppSettings>, success?: string) =>
     save({ ...settings, ...patch }, success);
 
-  const setAutostart = async (enabled: boolean) => {
-    setSaving(true);
-    try {
-      const persisted = await appServices.settings.setAutostart(enabled);
-      setSettings({ ...emptySettings, ...persisted });
-      notify(
-        enabled ? t("settings_autostart_on") : t("settings_autostart_off"),
-        t("settings_autostart_hint"),
-      );
-    } catch (error) {
-      notify(t("settings_autostart_failed"), String(error), "error");
-    } finally {
-      setSaving(false);
-    }
+  const setAutostart = (enabled: boolean): Promise<void> => {
+    // Optimistically mirror the backend semantics: disabling autostart also
+    // clears auto_start_engine, so later full-replace payloads built from
+    // this state can never revert the just-persisted autostart flag.
+    setSettings((current) => ({
+      ...current,
+      autostart: enabled,
+      auto_start_engine: enabled ? current.auto_start_engine : false,
+    }));
+    return enqueueSave(async () => {
+      setSaving(true);
+      try {
+        const persisted = await appServices.settings.setAutostart(enabled);
+        setSettings((current) => ({ ...emptySettings, ...persisted, ...current }));
+        notify(
+          enabled ? t("settings_autostart_on") : t("settings_autostart_off"),
+          t("settings_autostart_hint"),
+        );
+      } catch (error) {
+        const restored = await appServices.settings.get().catch(() => null);
+        if (restored) {
+          setSettings({ ...emptySettings, ...restored });
+        }
+        notify(t("settings_autostart_failed"), String(error), "error");
+      } finally {
+        setSaving(false);
+      }
+    });
   };
 
-  const setAutoStartEngine = async (enabled: boolean) => {
-    setSaving(true);
-    try {
-      const persisted = await appServices.settings.setAutoStartEngine(enabled);
-      setSettings({ ...emptySettings, ...persisted });
-      notify(
-        enabled ? t("settings_auto_start_engine_on") : t("settings_auto_start_engine_off"),
-        t("settings_auto_start_engine_hint"),
-      );
-    } catch (error) {
-      notify(t("settings_auto_start_engine_failed"), String(error), "error");
-    } finally {
-      setSaving(false);
-    }
+  const setAutoStartEngine = (enabled: boolean): Promise<void> => {
+    setSettings((current) => ({ ...current, auto_start_engine: enabled }));
+    return enqueueSave(async () => {
+      setSaving(true);
+      try {
+        const persisted = await appServices.settings.setAutoStartEngine(enabled);
+        setSettings((current) => ({ ...emptySettings, ...persisted, ...current }));
+        notify(
+          enabled ? t("settings_auto_start_engine_on") : t("settings_auto_start_engine_off"),
+          t("settings_auto_start_engine_hint"),
+        );
+      } catch (error) {
+        const restored = await appServices.settings.get().catch(() => null);
+        if (restored) {
+          setSettings({ ...emptySettings, ...restored });
+        }
+        notify(t("settings_auto_start_engine_failed"), String(error), "error");
+      } finally {
+        setSaving(false);
+      }
+    });
   };
 
   const inspectWfp = async () => {
@@ -257,31 +291,36 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
     }
   };
 
-  const runMigrationAction = async () => {
-    if (!migrationDialog) return;
-    setSaving(true);
-    try {
-      const next = migrationDialog === "migrate"
-        ? await appServices.settings.migrateLegacy()
-        : await appServices.settings.rollbackLegacy();
-      setSettings({ ...emptySettings, ...next });
-      setLocale(next.language);
-      setMigration(await appServices.settings.migrationStatus());
-      notify(
-        migrationDialog === "migrate"
-          ? text("旧版配置迁移完成", "Legacy settings migrated")
-          : text("迁移结果已回滚", "Migration rolled back"),
-        text(
-          "旧版配置原文件始终保留，未执行删除。",
-          "The original legacy configuration remains intact and was not deleted.",
-        ),
-      );
-      setMigrationDialogOpen(false);
-    } catch (error) {
-      notify(text("配置迁移操作失败", "Configuration migration failed"), String(error), "error");
-    } finally {
-      setSaving(false);
-    }
+  const runMigrationAction = (): Promise<void> => {
+    if (!migrationDialog) return Promise.resolve();
+    // Route through the save queue: a migration must not interleave with a
+    // queued full-replace save, or the migration result could be overwritten
+    // by an older payload.
+    return enqueueSave(async () => {
+      setSaving(true);
+      try {
+        const next = migrationDialog === "migrate"
+          ? await appServices.settings.migrateLegacy()
+          : await appServices.settings.rollbackLegacy();
+        setSettings({ ...emptySettings, ...next });
+        setLocale(next.language);
+        setMigration(await appServices.settings.migrationStatus());
+        notify(
+          migrationDialog === "migrate"
+            ? text("旧版配置迁移完成", "Legacy settings migrated")
+            : text("迁移结果已回滚", "Migration rolled back"),
+          text(
+            "旧版配置原文件始终保留，未执行删除。",
+            "The original legacy configuration remains intact and was not deleted.",
+          ),
+        );
+        setMigrationDialogOpen(false);
+      } catch (error) {
+        notify(text("配置迁移操作失败", "Configuration migration failed"), String(error), "error");
+      } finally {
+        setSaving(false);
+      }
+    });
   };
 
   return (
@@ -635,7 +674,7 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
             </DialogContent>
             <DialogActions>
               <DialogTrigger disableButtonEnhancement><Button>{t("routing_dialog_cancel")}</Button></DialogTrigger>
-              <Button appearance="primary" onClick={runMigrationAction}>
+              <Button appearance="primary" disabled={saving} onClick={runMigrationAction}>
                 {migrationDialog === "migrate"
                   ? text("确认迁移", "Confirm migration")
                   : text("确认回滚", "Confirm rollback")}

--- a/desktop/frontend/src/pages/SettingsPage.tsx
+++ b/desktop/frontend/src/pages/SettingsPage.tsx
@@ -32,7 +32,7 @@ import { GlassSurface } from "../components/material/GlassSurface";
 import { AppToaster } from "../components/AppToaster";
 import { desktopPlatform } from "../platform/desktop";
 import { appServices, type CompleteAppSettings, type ConfigMigrationStatus } from "../platform/services";
-import { SettingsSaveQueue } from "../platform/settingsQueue";
+import { SettingsSaveQueue, type SaveOutcome } from "../platform/settingsQueue";
 import { accentColours } from "../theme/appearance.presets";
 import { useAppearance } from "../theme/appearance.store";
 import { backgroundService } from "../theme/background.service";
@@ -124,27 +124,22 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
   // Serialize settings persistence and track per-field ownership: concurrent
   // saves would otherwise let an earlier response overwrite a newer optimistic
   // value, and a failed operation's recovery must not overwrite a later
-  // operation's success (see settingsQueue).
-  const saveQueue = useRef(new SettingsSaveQueue()).current;
+  // operation's success. Operations return SaveOutcome; the queue releases
+  // their ownership and merges authoritative values (see settingsQueue).
+  const saveQueue = useRef(new SettingsSaveQueue<CompleteAppSettings>()).current;
 
-  const enqueueSave = <T,>(operation: () => Promise<T>, fields: string[] | null): Promise<T> =>
-    saveQueue.enqueue(operation, fields);
+  useEffect(() => {
+    saveQueue.attach((updater) => setSettings(updater));
+  }, [saveQueue]);
 
-  const applyAuthoritative = (authoritative: CompleteAppSettings) => {
-    setSettings((current) =>
-      saveQueue.mergeAuthoritative({ ...emptySettings, ...authoritative }, current),
-    );
-  };
-
-  const applyRecovery = (ownedFields: string[] | null, authoritative: CompleteAppSettings) => {
-    setSettings((current) =>
-      saveQueue.recoverAuthoritative(
-        ownedFields,
-        { ...emptySettings, ...authoritative },
-        current,
-      ),
-    );
-  };
+  const enqueueSave = <T,>(operation: () => Promise<SaveOutcome<T, CompleteAppSettings>>, fields: string[] | null): Promise<T> =>
+    saveQueue.enqueue(operation, fields).catch((error) => {
+      // Errors are already surfaced via notify inside the operation; the
+      // queue's rejection is only a control-flow signal. Swallow it here so
+      // callers (React event handlers) never see an unhandled rejection.
+      console.error("settings save failed:", error);
+      return undefined as T;
+    });
 
   const toasterId = useId("settings-toaster");
   const { dispatchToast } = useToastController(toasterId);
@@ -186,14 +181,18 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       setSaving(true);
       try {
         const persisted = await appServices.settings.update(next);
-        applyAuthoritative(persisted);
         setLocale(persisted.language);
         notify(t("infobar_success"), success ?? text("设置已保存", "Settings saved"));
+        return { ok: true as const, value: undefined, authoritative: persisted };
       } catch (error) {
         const restored = await appServices.settings.get().catch(() => next);
-        applyRecovery(fields, restored);
         setLocale(restored.language);
         notify(text("保存失败", "Save failed"), String(error), "error");
+        return {
+          ok: false as const,
+          error: error instanceof Error ? error : new Error(String(error)),
+          restore: restored,
+        };
       } finally {
         setSaving(false);
       }
@@ -216,17 +215,19 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       setSaving(true);
       try {
         const persisted = await appServices.settings.setAutostart(enabled);
-        applyAuthoritative(persisted);
         notify(
           enabled ? t("settings_autostart_on") : t("settings_autostart_off"),
           t("settings_autostart_hint"),
         );
+        return { ok: true as const, value: undefined, authoritative: persisted };
       } catch (error) {
         const restored = await appServices.settings.get().catch(() => null);
-        if (restored) {
-          applyRecovery(["autostart", "auto_start_engine"], restored);
-        }
         notify(t("settings_autostart_failed"), String(error), "error");
+        return {
+          ok: false as const,
+          error: error instanceof Error ? error : new Error(String(error)),
+          restore: restored,
+        };
       } finally {
         setSaving(false);
       }
@@ -239,17 +240,19 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
       setSaving(true);
       try {
         const persisted = await appServices.settings.setAutoStartEngine(enabled);
-        applyAuthoritative(persisted);
         notify(
           enabled ? t("settings_auto_start_engine_on") : t("settings_auto_start_engine_off"),
           t("settings_auto_start_engine_hint"),
         );
+        return { ok: true as const, value: undefined, authoritative: persisted };
       } catch (error) {
         const restored = await appServices.settings.get().catch(() => null);
-        if (restored) {
-          applyRecovery(["auto_start_engine"], restored);
-        }
         notify(t("settings_auto_start_engine_failed"), String(error), "error");
+        return {
+          ok: false as const,
+          error: error instanceof Error ? error : new Error(String(error)),
+          restore: restored,
+        };
       } finally {
         setSaving(false);
       }
@@ -316,7 +319,6 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
         const next = migrationDialog === "migrate"
           ? await appServices.settings.migrateLegacy()
           : await appServices.settings.rollbackLegacy();
-        applyAuthoritative(next);
         setLocale(next.language);
         setMigration(await appServices.settings.migrationStatus());
         notify(
@@ -329,8 +331,14 @@ export function SettingsPage({ onOpenBlockedDomains }: { onOpenBlockedDomains: (
           ),
         );
         setMigrationDialogOpen(false);
+        return { ok: true as const, value: undefined, authoritative: next };
       } catch (error) {
         notify(text("配置迁移操作失败", "Configuration migration failed"), String(error), "error");
+        return {
+          ok: false as const,
+          error: error instanceof Error ? error : new Error(String(error)),
+          restore: null,
+        };
       } finally {
         setSaving(false);
       }

--- a/desktop/frontend/src/platform/settingsQueue.test.ts
+++ b/desktop/frontend/src/platform/settingsQueue.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { SettingsSaveQueue } from "./settingsQueue";
+import { SettingsSaveQueue, type SaveOutcome } from "./settingsQueue";
 
-const authoritative = (patch: Record<string, unknown>) => ({
+type Settings = Record<string, unknown>;
+
+const settings = (patch: Record<string, unknown>): Settings => ({
   mode: "tun",
   language: "zh",
   socks_port: 10800,
@@ -16,120 +18,188 @@ const authoritative = (patch: Record<string, unknown>) => ({
   ...patch,
 });
 
+const ok = (patch: Record<string, unknown>): SaveOutcome<void, Settings> => ({
+  ok: true,
+  value: undefined,
+  authoritative: settings(patch),
+});
+
+const fail = (message: string, patch: Record<string, unknown>): SaveOutcome<void, Settings> => ({
+  ok: false,
+  error: new Error(message),
+  restore: settings(patch),
+});
+
+/** Drives the queue exactly like the React settings page: a mutable current
+ * state, an apply sink that runs updaters immediately, and an optimistic()
+ * helper that mimics the pre-enqueue setSettings call. The server state is
+ * simulated as cumulative: every successful save persists onto the previous
+ * one, like the real backend returning the full settings object. */
+function harness() {
+  let current: Settings = settings({});
+  let server: Settings = settings({});
+  const queue = new SettingsSaveQueue<Settings>();
+  queue.attach((updater) => {
+    current = updater(current);
+  });
+  return {
+    queue,
+    get current() {
+      return current;
+    },
+    optimistic(patch: Record<string, unknown>) {
+      current = { ...current, ...patch };
+    },
+    /** Simulates the backend persisting patch and returning full settings. */
+    persist(patch: Record<string, unknown>) {
+      server = settings({ ...server, ...patch });
+      return ok(server);
+    },
+    serverPatch(patch: Record<string, unknown>) {
+      return settings({ ...server, ...patch });
+    },
+  };
+}
+
 describe("SettingsSaveQueue", () => {
   it("merges optimistic values only for operations still queued", async () => {
-    const queue = new SettingsSaveQueue();
+    const h = harness();
     let resolveA: () => void = () => {};
     const gateA = new Promise<void>((resolve) => {
       resolveA = resolve;
     });
-    const pendingA = queue.enqueue(
-      () => gateA.then(() => authoritative({ close_to_tray: true })),
+    const pendingA = h.queue.enqueue(
+      () => gateA.then(() => h.persist({ close_to_tray: true })),
       ["close_to_tray"],
     );
     // Operation B is queued while A is still running; B's optimistic value
     // must survive A's authoritative write-back.
-    const pendingB = queue.enqueue(
-      () => Promise.resolve(authoritative({ autostart: true })),
+    h.optimistic({ autostart: true });
+    const pendingB = h.queue.enqueue(
+      () => Promise.resolve(h.persist({ autostart: true })),
       ["autostart"],
     );
-    const mergedWhileBQueued = queue.mergeAuthoritative(
-      authoritative({ close_to_tray: true, autostart: false }),
-      authoritative({ close_to_tray: true, autostart: true }),
-    );
-    expect(mergedWhileBQueued.autostart).toBe(true);
     resolveA();
     await Promise.all([pendingA, pendingB]);
-    // B has run; nothing is queued anymore, so the authoritative response
-    // wins completely.
-    const mergedAfterAll = queue.mergeAuthoritative(
-      authoritative({ close_to_tray: true, autostart: true }),
-      authoritative({ close_to_tray: false, autostart: false }),
-    );
-    expect(mergedAfterAll).toEqual(
-      authoritative({ close_to_tray: true, autostart: true }),
-    );
+    expect(h.current).toMatchObject({ close_to_tray: true, autostart: true });
   });
 
   it("does not let a failed earlier operation's recovery overwrite a later success", async () => {
-    const queue = new SettingsSaveQueue();
-    // Operation A fails; its recovery re-fetches server truth (old values).
-    const pendingA = queue.enqueue(
-      () => Promise.reject(new Error("simulated network failure")),
+    const h = harness();
+    const pendingA = h.queue.enqueue(
+      () => Promise.resolve(fail("simulated network failure", { close_to_tray: false })),
       ["close_to_tray"],
     );
-    // Operation B is already queued with its own optimistic value; gate its
-    // completion so the recovery merge happens while B is still pending.
-    let resolveB: () => void = () => {};
-    const gateB = new Promise<void>((resolve) => {
-      resolveB = resolve;
-    });
-    const pendingB = queue.enqueue(
-      () => gateB.then(() => authoritative({ close_to_tray: true })),
+    h.optimistic({ close_to_tray: true });
+    const pendingB = h.queue.enqueue(
+      () => Promise.resolve(h.persist({ close_to_tray: true })),
       ["close_to_tray"],
     );
     await expect(pendingA).rejects.toThrow("simulated network failure");
-    // After A failed and the UI was reset to server truth, B is still queued:
-    // the recovery merge must keep B's optimistic field, not the stale truth.
-    const mergedDuringRecovery = queue.mergeAuthoritative(
-      authoritative({ close_to_tray: false }),
-      authoritative({ close_to_tray: true }),
-    );
-    expect(mergedDuringRecovery.close_to_tray).toBe(true);
-    resolveB();
+    // After A's recovery reset the field to server truth, B is still queued:
+    // its optimistic close_to_tray survives the recovery merge.
+    expect(h.current.close_to_tray).toBe(true);
     await pendingB;
-    // B succeeded; its response is authoritative and nothing is queued.
-    const mergedAfterB = queue.mergeAuthoritative(
-      authoritative({ close_to_tray: true }),
-      authoritative({ close_to_tray: false }),
+    expect(h.current.close_to_tray).toBe(true);
+  });
+
+  it("full-replace success applies its authoritative value (not its own queued flag)", async () => {
+    const h = harness();
+    const pending = h.queue.enqueue(
+      () => Promise.resolve(h.persist({ dns_server: "1.1.1.1" })),
+      null,
     );
-    expect(mergedAfterB.close_to_tray).toBe(true);
+    await pending;
+    expect(h.current.dns_server).toBe("1.1.1.1");
+  });
+
+  it("full-replace failure restores the server truth", async () => {
+    const h = harness();
+    const pending = h.queue.enqueue(
+      () => Promise.resolve(fail("simulated failure", { dns_server: "223.5.5.5" })),
+      null,
+    );
+    await expect(pending).rejects.toThrow("simulated failure");
+    expect(h.current.dns_server).toBe("223.5.5.5");
+  });
+
+  it("migration success applies the returned configuration", async () => {
+    const h = harness();
+    const pending = h.queue.enqueue(
+      () => Promise.resolve(ok({ language: "en", close_to_tray: true })),
+      null,
+    );
+    await pending;
+    expect(h.current.language).toBe("en");
+    expect(h.current.close_to_tray).toBe(true);
+  });
+
+  it("failed operation without restore keeps the UI unchanged while later ops queue", async () => {
+    const h = harness();
+    // get() failed inside the operation: restore is null and the queue must
+    // not wipe the optimistic value of the still-queued operation B.
+    const pendingA = h.queue.enqueue(
+      () =>
+        Promise.resolve({
+          ok: false as const,
+          error: new Error("get failed"),
+          restore: null,
+        }),
+      ["autostart"],
+    );
+    h.optimistic({ autostart: true });
+    const pendingB = h.queue.enqueue(
+      () => Promise.resolve(h.persist({ autostart: true })),
+      ["autostart"],
+    );
+    await expect(pendingA).rejects.toThrow("get failed");
+    expect(h.current.autostart).toBe(true);
+    await pendingB;
+    expect(h.current.autostart).toBe(true);
+  });
+
+  it("same-field sequence with a failed first operation converges to disk truth", async () => {
+    const h = harness();
+    // A=true fails and recovers to server false; B=false and C=true both
+    // succeed afterwards. Disk ends at true, so the UI must too.
+    const pendingA = h.queue.enqueue(
+      () => Promise.resolve(fail("simulated failure", { autostart: false })),
+      ["autostart"],
+    );
+    h.optimistic({ autostart: true });
+    const pendingB = h.queue.enqueue(
+      () => Promise.resolve(h.persist({ autostart: false })),
+      ["autostart"],
+    );
+    h.optimistic({ autostart: false });
+    const pendingC = h.queue.enqueue(
+      () => Promise.resolve(h.persist({ autostart: true })),
+      ["autostart"],
+    );
+    h.optimistic({ autostart: true });
+    await expect(pendingA).rejects.toThrow("simulated failure");
+    await Promise.all([pendingB, pendingC]);
+    expect(h.current.autostart).toBe(true);
   });
 
   it("keeps queued full-replace optimistic values until the operation runs", async () => {
-    const queue = new SettingsSaveQueue();
-    const pending = queue.enqueue(
-      () => Promise.resolve(authoritative({ dns_server: "1.1.1.1" })),
+    const h = harness();
+    let resolveFull: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      resolveFull = resolve;
+    });
+    const pending = h.queue.enqueue(
+      () => gate.then(() => h.persist({ dns_server: "1.1.1.1" })),
       null,
     );
-    const merged = queue.mergeAuthoritative(
-      authoritative({ dns_server: "223.5.5.5" }),
-      authoritative({ dns_server: "1.1.1.1" }),
+    // While the full-replace operation is queued, a merge must keep the
+    // current optimistic snapshot instead of the stale authoritative value.
+    const merged = h.queue.mergeAuthoritative(
+      settings({ dns_server: "223.5.5.5" }),
+      settings({ dns_server: "1.1.1.1" }),
     );
     expect(merged.dns_server).toBe("1.1.1.1");
+    resolveFull();
     await pending;
-    const mergedAfter = queue.mergeAuthoritative(
-      authoritative({ dns_server: "1.1.1.1" }),
-      authoritative({ dns_server: "223.5.5.5" }),
-    );
-    expect(mergedAfter.dns_server).toBe("1.1.1.1");
-  });
-
-  it("recovery merge inside the failed operation still prefers authoritative values for its own fields", async () => {
-    const queue = new SettingsSaveQueue();
-    // The recovery merge runs inside the operation, before its field
-    // ownership is released by the finally block, exactly like the production
-    // catch block.
-    let recoveredSnapshot: Record<string, unknown> = {};
-    const pendingA = queue.enqueue(async () => {
-      recoveredSnapshot = queue.recoverAuthoritative(
-        ["close_to_tray"],
-        authoritative({ close_to_tray: false, autostart: false }),
-        authoritative({ close_to_tray: true, autostart: true }),
-      );
-      throw new Error("simulated failure");
-    }, ["close_to_tray"]);
-    // B is queued behind A with its own optimistic value.
-    const pendingB = queue.enqueue(
-      () => Promise.resolve(authoritative({ autostart: true })),
-      ["autostart"],
-    );
-    await expect(pendingA).rejects.toThrow("simulated failure");
-    // A's own field must come from the authoritative (stale server) value
-    // even though A's ownership was not released yet; B's queued field
-    // survives.
-    expect(recoveredSnapshot.close_to_tray).toBe(false);
-    expect(recoveredSnapshot.autostart).toBe(true);
-    await pendingB;
   });
 });

--- a/desktop/frontend/src/platform/settingsQueue.test.ts
+++ b/desktop/frontend/src/platform/settingsQueue.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { SettingsSaveQueue } from "./settingsQueue";
+
+const authoritative = (patch: Record<string, unknown>) => ({
+  mode: "tun",
+  language: "zh",
+  socks_port: 10800,
+  http_port: 10801,
+  weighted: false,
+  strict_route: true,
+  close_to_tray: false,
+  autostart: false,
+  auto_start_engine: false,
+  dns_server: "223.5.5.5",
+  dns_policy: "auto",
+  ...patch,
+});
+
+describe("SettingsSaveQueue", () => {
+  it("merges optimistic values only for operations still queued", async () => {
+    const queue = new SettingsSaveQueue();
+    let resolveA: () => void = () => {};
+    const gateA = new Promise<void>((resolve) => {
+      resolveA = resolve;
+    });
+    const pendingA = queue.enqueue(
+      () => gateA.then(() => authoritative({ close_to_tray: true })),
+      ["close_to_tray"],
+    );
+    // Operation B is queued while A is still running; B's optimistic value
+    // must survive A's authoritative write-back.
+    const pendingB = queue.enqueue(
+      () => Promise.resolve(authoritative({ autostart: true })),
+      ["autostart"],
+    );
+    const mergedWhileBQueued = queue.mergeAuthoritative(
+      authoritative({ close_to_tray: true, autostart: false }),
+      authoritative({ close_to_tray: true, autostart: true }),
+    );
+    expect(mergedWhileBQueued.autostart).toBe(true);
+    resolveA();
+    await Promise.all([pendingA, pendingB]);
+    // B has run; nothing is queued anymore, so the authoritative response
+    // wins completely.
+    const mergedAfterAll = queue.mergeAuthoritative(
+      authoritative({ close_to_tray: true, autostart: true }),
+      authoritative({ close_to_tray: false, autostart: false }),
+    );
+    expect(mergedAfterAll).toEqual(
+      authoritative({ close_to_tray: true, autostart: true }),
+    );
+  });
+
+  it("does not let a failed earlier operation's recovery overwrite a later success", async () => {
+    const queue = new SettingsSaveQueue();
+    // Operation A fails; its recovery re-fetches server truth (old values).
+    const pendingA = queue.enqueue(
+      () => Promise.reject(new Error("simulated network failure")),
+      ["close_to_tray"],
+    );
+    // Operation B is already queued with its own optimistic value; gate its
+    // completion so the recovery merge happens while B is still pending.
+    let resolveB: () => void = () => {};
+    const gateB = new Promise<void>((resolve) => {
+      resolveB = resolve;
+    });
+    const pendingB = queue.enqueue(
+      () => gateB.then(() => authoritative({ close_to_tray: true })),
+      ["close_to_tray"],
+    );
+    await expect(pendingA).rejects.toThrow("simulated network failure");
+    // After A failed and the UI was reset to server truth, B is still queued:
+    // the recovery merge must keep B's optimistic field, not the stale truth.
+    const mergedDuringRecovery = queue.mergeAuthoritative(
+      authoritative({ close_to_tray: false }),
+      authoritative({ close_to_tray: true }),
+    );
+    expect(mergedDuringRecovery.close_to_tray).toBe(true);
+    resolveB();
+    await pendingB;
+    // B succeeded; its response is authoritative and nothing is queued.
+    const mergedAfterB = queue.mergeAuthoritative(
+      authoritative({ close_to_tray: true }),
+      authoritative({ close_to_tray: false }),
+    );
+    expect(mergedAfterB.close_to_tray).toBe(true);
+  });
+
+  it("keeps queued full-replace optimistic values until the operation runs", async () => {
+    const queue = new SettingsSaveQueue();
+    const pending = queue.enqueue(
+      () => Promise.resolve(authoritative({ dns_server: "1.1.1.1" })),
+      null,
+    );
+    const merged = queue.mergeAuthoritative(
+      authoritative({ dns_server: "223.5.5.5" }),
+      authoritative({ dns_server: "1.1.1.1" }),
+    );
+    expect(merged.dns_server).toBe("1.1.1.1");
+    await pending;
+    const mergedAfter = queue.mergeAuthoritative(
+      authoritative({ dns_server: "1.1.1.1" }),
+      authoritative({ dns_server: "223.5.5.5" }),
+    );
+    expect(mergedAfter.dns_server).toBe("1.1.1.1");
+  });
+
+  it("recovery merge inside the failed operation still prefers authoritative values for its own fields", async () => {
+    const queue = new SettingsSaveQueue();
+    // The recovery merge runs inside the operation, before its field
+    // ownership is released by the finally block, exactly like the production
+    // catch block.
+    let recoveredSnapshot: Record<string, unknown> = {};
+    const pendingA = queue.enqueue(async () => {
+      recoveredSnapshot = queue.recoverAuthoritative(
+        ["close_to_tray"],
+        authoritative({ close_to_tray: false, autostart: false }),
+        authoritative({ close_to_tray: true, autostart: true }),
+      );
+      throw new Error("simulated failure");
+    }, ["close_to_tray"]);
+    // B is queued behind A with its own optimistic value.
+    const pendingB = queue.enqueue(
+      () => Promise.resolve(authoritative({ autostart: true })),
+      ["autostart"],
+    );
+    await expect(pendingA).rejects.toThrow("simulated failure");
+    // A's own field must come from the authoritative (stale server) value
+    // even though A's ownership was not released yet; B's queued field
+    // survives.
+    expect(recoveredSnapshot.close_to_tray).toBe(false);
+    expect(recoveredSnapshot.autostart).toBe(true);
+    await pendingB;
+  });
+});

--- a/desktop/frontend/src/platform/settingsQueue.ts
+++ b/desktop/frontend/src/platform/settingsQueue.ts
@@ -1,19 +1,39 @@
 // Serializes settings persistence and tracks which fields each queued
-// operation owns. Authoritative responses (persisted state, or server truth
-// re-fetched after a failure) are merged so that only optimistic values of
-// operations still queued or running survive; fields of finished operations
-// always come from the authoritative value. Without this, a failed earlier
-// operation's recovery (which resets the UI to server truth) would let stale
-// values overwrite a later operation's successful response.
-export class SettingsSaveQueue {
+// operation owns. Operations never merge state themselves: they return a
+// SaveOutcome (authoritative value on success, server truth to restore on
+// failure), and the queue releases the operation's field ownership first and
+// then merges. Because the merge always happens after ownership release,
+// results are correct regardless of React scheduling, a failed operation can
+// never overwrite a later success, and a full-replace operation's own
+// authoritative value is never mistaken for a queued optimistic value.
+
+export type SaveFields = string[] | null; // null = all fields
+
+export type SaveOutcome<TValue, TState extends object> =
+  | { ok: true; value: TValue; authoritative: TState }
+  | { ok: false; error: Error; restore: TState | null }; // null = keep UI as-is
+
+export class SettingsSaveQueue<TState extends object> {
   private chain: Promise<void> = Promise.resolve();
   // Reference counts per field: the same field can be owned by several queued
-  // operations, and an earlier operation starting must not drop the marker
+  // operations, and an earlier operation finishing must not drop the marker
   // for a later one.
   private pendingFieldCounts = new Map<string, number>();
   private allFieldsQueuedCount = 0;
+  private applySink:
+    | ((updater: (current: TState) => TState) => void)
+    | null = null;
 
-  enqueue<T>(operation: () => Promise<T>, fields: string[] | null): Promise<T> {
+  /** React side registers its state setter here; the queue drives merges
+   * through it after releasing ownership. */
+  attach(applySink: (updater: (current: TState) => TState) => void) {
+    this.applySink = applySink;
+  }
+
+  enqueue<TValue>(
+    operation: () => Promise<SaveOutcome<TValue, TState>>,
+    fields: SaveFields,
+  ): Promise<TValue> {
     if (fields === null) {
       this.allFieldsQueuedCount += 1;
     } else {
@@ -25,25 +45,22 @@ export class SettingsSaveQueue {
       }
     }
     const next = this.chain.then(async () => {
+      let outcome: SaveOutcome<TValue, TState>;
       try {
-        return await operation();
+        outcome = await operation();
       } finally {
-        // Release field ownership when the operation finishes, success or
-        // failure: while it is still running, its optimistic values must
-        // survive concurrent merges.
-        if (fields === null) {
-          this.allFieldsQueuedCount -= 1;
-        } else {
-          for (const field of fields) {
-            const count = (this.pendingFieldCounts.get(field) ?? 1) - 1;
-            if (count <= 0) {
-              this.pendingFieldCounts.delete(field);
-            } else {
-              this.pendingFieldCounts.set(field, count);
-            }
-          }
-        }
+        // Release ownership before merging: this operation's outcome (and
+        // only this operation's) is now authoritative.
+        this.releaseFields(fields);
       }
+      if (outcome.ok) {
+        this.applyMerged(outcome.authoritative);
+        return outcome.value;
+      }
+      if (outcome.restore !== null) {
+        this.applyMerged(outcome.restore);
+      }
+      throw outcome.error;
     });
     this.chain = next.then(
       () => undefined,
@@ -52,7 +69,7 @@ export class SettingsSaveQueue {
     return next;
   }
 
-  mergeAuthoritative<T extends object>(authoritative: T, current: T): T {
+  mergeAuthoritative(authoritative: TState, current: TState): TState {
     const merged = { ...authoritative } as Record<string, unknown>;
     if (this.allFieldsQueuedCount > 0) {
       // A queued full-replace operation will persist every field; keep all
@@ -64,34 +81,25 @@ export class SettingsSaveQueue {
         merged[field] = (current as Record<string, unknown>)[field];
       }
     }
-    return merged as T;
+    return merged as TState;
   }
 
-  /**
-   * Merges an authoritative response for a failed operation whose own fields
-   * must come from the authoritative value (its optimistic values are stale),
-   * while optimistic values of other queued operations survive. Unlike
-   * mergeAuthoritative, this does not depend on the caller having already
-   * released the failed operation's field ownership, so it stays correct
-   * regardless of when the recovery merge runs.
-   */
-  recoverAuthoritative<T extends object>(
-    ownedFields: string[] | null,
-    authoritative: T,
-    current: T,
-  ): T {
-    const merged = { ...authoritative } as Record<string, unknown>;
-    if (this.allFieldsQueuedCount > 0) {
-      // A queued full-replace operation will persist every field; keep all
-      // optimistic values until it runs.
-      return { ...current };
-    }
-    const owned = new Set(ownedFields ?? []);
-    for (const field of this.pendingFieldCounts.keys()) {
-      if (!owned.has(field) && field in current) {
-        merged[field] = (current as Record<string, unknown>)[field];
+  private releaseFields(fields: SaveFields) {
+    if (fields === null) {
+      this.allFieldsQueuedCount -= 1;
+    } else {
+      for (const field of fields) {
+        const count = (this.pendingFieldCounts.get(field) ?? 1) - 1;
+        if (count <= 0) {
+          this.pendingFieldCounts.delete(field);
+        } else {
+          this.pendingFieldCounts.set(field, count);
+        }
       }
     }
-    return merged as T;
+  }
+
+  private applyMerged(authoritative: TState) {
+    this.applySink?.((current) => this.mergeAuthoritative(authoritative, current));
   }
 }

--- a/desktop/frontend/src/platform/settingsQueue.ts
+++ b/desktop/frontend/src/platform/settingsQueue.ts
@@ -1,0 +1,97 @@
+// Serializes settings persistence and tracks which fields each queued
+// operation owns. Authoritative responses (persisted state, or server truth
+// re-fetched after a failure) are merged so that only optimistic values of
+// operations still queued or running survive; fields of finished operations
+// always come from the authoritative value. Without this, a failed earlier
+// operation's recovery (which resets the UI to server truth) would let stale
+// values overwrite a later operation's successful response.
+export class SettingsSaveQueue {
+  private chain: Promise<void> = Promise.resolve();
+  // Reference counts per field: the same field can be owned by several queued
+  // operations, and an earlier operation starting must not drop the marker
+  // for a later one.
+  private pendingFieldCounts = new Map<string, number>();
+  private allFieldsQueuedCount = 0;
+
+  enqueue<T>(operation: () => Promise<T>, fields: string[] | null): Promise<T> {
+    if (fields === null) {
+      this.allFieldsQueuedCount += 1;
+    } else {
+      for (const field of fields) {
+        this.pendingFieldCounts.set(
+          field,
+          (this.pendingFieldCounts.get(field) ?? 0) + 1,
+        );
+      }
+    }
+    const next = this.chain.then(async () => {
+      try {
+        return await operation();
+      } finally {
+        // Release field ownership when the operation finishes, success or
+        // failure: while it is still running, its optimistic values must
+        // survive concurrent merges.
+        if (fields === null) {
+          this.allFieldsQueuedCount -= 1;
+        } else {
+          for (const field of fields) {
+            const count = (this.pendingFieldCounts.get(field) ?? 1) - 1;
+            if (count <= 0) {
+              this.pendingFieldCounts.delete(field);
+            } else {
+              this.pendingFieldCounts.set(field, count);
+            }
+          }
+        }
+      }
+    });
+    this.chain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+
+  mergeAuthoritative<T extends object>(authoritative: T, current: T): T {
+    const merged = { ...authoritative } as Record<string, unknown>;
+    if (this.allFieldsQueuedCount > 0) {
+      // A queued full-replace operation will persist every field; keep all
+      // optimistic values until it runs.
+      return { ...current };
+    }
+    for (const field of this.pendingFieldCounts.keys()) {
+      if (field in current) {
+        merged[field] = (current as Record<string, unknown>)[field];
+      }
+    }
+    return merged as T;
+  }
+
+  /**
+   * Merges an authoritative response for a failed operation whose own fields
+   * must come from the authoritative value (its optimistic values are stale),
+   * while optimistic values of other queued operations survive. Unlike
+   * mergeAuthoritative, this does not depend on the caller having already
+   * released the failed operation's field ownership, so it stays correct
+   * regardless of when the recovery merge runs.
+   */
+  recoverAuthoritative<T extends object>(
+    ownedFields: string[] | null,
+    authoritative: T,
+    current: T,
+  ): T {
+    const merged = { ...authoritative } as Record<string, unknown>;
+    if (this.allFieldsQueuedCount > 0) {
+      // A queued full-replace operation will persist every field; keep all
+      // optimistic values until it runs.
+      return { ...current };
+    }
+    const owned = new Set(ownedFields ?? []);
+    for (const field of this.pendingFieldCounts.keys()) {
+      if (!owned.has(field) && field in current) {
+        merged[field] = (current as Record<string, unknown>)[field];
+      }
+    }
+    return merged as T;
+  }
+}

--- a/engine/internal/dns/resolver.go
+++ b/engine/internal/dns/resolver.go
@@ -277,7 +277,7 @@ func (r *Resolver) resolveUncached(
 }
 
 const (
-	// maxDoHRace limits concurrent DoH dials per lookup; see resolveDoH.
+	// maxDoHRace limits concurrent DoH dials per batch; see resolveDoH.
 	maxDoHRace = 2
 )
 
@@ -291,39 +291,70 @@ func (r *Resolver) resolveDoH(
 	if len(endpoints) == 0 {
 		return Result{}, 0, fmt.Errorf("no DoH endpoint configured")
 	}
+	// Race endpoints in small batches, each with its own bounded time budget.
+	// A single shared deadline would let the first endpoints consume the whole
+	// budget while blocked, starving later (possibly healthy) endpoints of any
+	// attempt; per-batch budgets guarantee every batch gets a real chance.
+	batchCount := (len(endpoints) + maxDoHRace - 1) / maxDoHRace
+	batchBudget := r.config.QueryTimeout / time.Duration(batchCount)
+	var failures []error
+	for start := 0; start < len(endpoints); start += maxDoHRace {
+		end := start + maxDoHRace
+		if end > len(endpoints) {
+			end = len(endpoints)
+		}
+		batch := endpoints[start:end]
+		batchCtx, cancel := context.WithTimeout(ctx, batchBudget)
+		result, ttl, err := r.raceDoHBatch(
+			batchCtx,
+			batch,
+			domain,
+			recordType,
+			binding,
+		)
+		cancel()
+		if err == nil {
+			return result, ttl, nil
+		}
+		failures = append(failures, err)
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return Result{}, 0, errors.Join(failures...)
+}
+
+func (r *Resolver) raceDoHBatch(
+	ctx context.Context,
+	batch []Endpoint,
+	domain string,
+	recordType uint16,
+	binding Binding,
+) (Result, time.Duration, error) {
 	type outcome struct {
 		result Result
 		ttl    time.Duration
 		err    error
 	}
-	raceContext, cancel := context.WithCancel(ctx)
-	defer cancel()
-	outcomes := make(chan outcome, len(endpoints))
-	// Cap how many endpoints dial concurrently: racing all five at once
-	// multiplies connections and goroutines while DoH is blocked, for little
-	// latency benefit once the first responder wins.
-	semaphore := make(chan struct{}, maxDoHRace)
-	for _, endpoint := range endpoints {
+	outcomes := make(chan outcome, len(batch))
+	for _, endpoint := range batch {
 		endpoint := endpoint
 		go func() {
-			semaphore <- struct{}{}
 			result, ttl, err := r.queryDoH(
-				raceContext,
+				ctx,
 				domain,
 				recordType,
 				binding,
 				endpoint,
 			)
-			<-semaphore
 			outcomes <- outcome{result: result, ttl: ttl, err: err}
 		}()
 	}
 	var failures []error
-	for range endpoints {
+	for range batch {
 		select {
 		case outcome := <-outcomes:
 			if outcome.err == nil {
-				cancel()
 				r.dohSuccesses.Add(1)
 				return outcome.result, outcome.ttl, nil
 			}

--- a/engine/internal/dns/resolver.go
+++ b/engine/internal/dns/resolver.go
@@ -276,6 +276,11 @@ func (r *Resolver) resolveUncached(
 	return r.resolveLegacy(ctx, domain, wireType, binding)
 }
 
+const (
+	// maxDoHRace limits concurrent DoH dials per lookup; see resolveDoH.
+	maxDoHRace = 2
+)
+
 func (r *Resolver) resolveDoH(
 	ctx context.Context,
 	domain string,
@@ -294,9 +299,14 @@ func (r *Resolver) resolveDoH(
 	raceContext, cancel := context.WithCancel(ctx)
 	defer cancel()
 	outcomes := make(chan outcome, len(endpoints))
+	// Cap how many endpoints dial concurrently: racing all five at once
+	// multiplies connections and goroutines while DoH is blocked, for little
+	// latency benefit once the first responder wins.
+	semaphore := make(chan struct{}, maxDoHRace)
 	for _, endpoint := range endpoints {
 		endpoint := endpoint
 		go func() {
+			semaphore <- struct{}{}
 			result, ttl, err := r.queryDoH(
 				raceContext,
 				domain,
@@ -304,6 +314,7 @@ func (r *Resolver) resolveDoH(
 				binding,
 				endpoint,
 			)
+			<-semaphore
 			outcomes <- outcome{result: result, ttl: ttl, err: err}
 		}()
 	}

--- a/engine/internal/dns/resolver_test.go
+++ b/engine/internal/dns/resolver_test.go
@@ -382,3 +382,63 @@ func TestDoHRaceIsBounded(t *testing.T) {
 		t.Fatalf("concurrent DoH dials peaked at %d, want <= 2", peak.Load())
 	}
 }
+
+func TestDoHRaceAdvancesToLaterEndpoints(t *testing.T) {
+	endpoints := Endpoints(PolicyAuto)
+	if len(endpoints) < 3 {
+		t.Skip("PolicyAuto no longer provides at least three endpoints")
+	}
+	blocked := map[string]bool{
+		net.JoinHostPort(endpoints[0].IP, "443"): true,
+		net.JoinHostPort(endpoints[1].IP, "443"): true,
+	}
+	var laterAttempts atomic.Int64
+	var laterCtxAlive atomic.Bool
+	laterCtxAlive.Store(true)
+	// Barrier: later endpoints must only dial after both blocked endpoints have
+	// already started dialing, so the test is deterministic regardless of
+	// goroutine scheduling order.
+	blockedStarted := make(chan struct{})
+	var blockedCount atomic.Int64
+	const blockedTotal = 2
+	dial := func(ctx context.Context, _ string, address string, _ Binding) (net.Conn, error) {
+		if blocked[address] {
+			if blockedCount.Add(1) == blockedTotal {
+				close(blockedStarted)
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		<-blockedStarted
+		if strings.HasSuffix(address, ":443") {
+			if laterAttempts.Add(1) == 1 && ctx.Err() != nil {
+				laterCtxAlive.Store(false)
+			}
+		}
+		return nil, errors.New("simulated TLS failure")
+	}
+	resolver, err := New(context.Background(), Config{
+		Policy:          PolicyAuto,
+		LegacyServers:   []string{"192.0.2.53"},
+		CacheTTL:        time.Minute,
+		QueryTimeout:    3 * time.Second,
+		MaxCacheEntries: 16,
+	}, dial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), Query{
+		Domain:     "later.example",
+		RecordType: RecordA,
+		Binding:    loopbackBinding,
+	})
+	if err == nil {
+		t.Fatal("expected resolution to fail (DoH and legacy all fail)")
+	}
+	if laterAttempts.Load() == 0 {
+		t.Fatal("endpoints after the first batch were never dialed")
+	}
+	if !laterCtxAlive.Load() {
+		t.Fatal("later endpoint was dialed with an already-canceled context; it never got a chance to answer")
+	}
+}

--- a/engine/internal/dns/resolver_test.go
+++ b/engine/internal/dns/resolver_test.go
@@ -344,3 +344,41 @@ func answeringConnection(
 	}()
 	return client
 }
+
+func TestDoHRaceIsBounded(t *testing.T) {
+	var concurrent atomic.Int64
+	var peak atomic.Int64
+	dial := func(_ context.Context, _ string, _ string, _ Binding) (net.Conn, error) {
+		now := concurrent.Add(1)
+		defer concurrent.Add(-1)
+		for {
+			prev := peak.Load()
+			if now <= prev || peak.CompareAndSwap(prev, now) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		return nil, errors.New("simulated DoH outage")
+	}
+	resolver, err := New(context.Background(), Config{
+		Policy:          PolicyAuto,
+		LegacyServers:   []string{"192.0.2.53"},
+		CacheTTL:        time.Minute,
+		QueryTimeout:    2 * time.Second,
+		MaxCacheEntries: 16,
+	}, dial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), Query{
+		Domain:     "race.example",
+		RecordType: RecordA,
+		Binding:    loopbackBinding,
+	})
+	if err == nil {
+		t.Fatal("expected resolution to fail with simulated DoH and legacy outage")
+	}
+	if peak.Load() > 2 {
+		t.Fatalf("concurrent DoH dials peaked at %d, want <= 2", peak.Load())
+	}
+}


### PR DESCRIPTION
## 概述

来自 #50 的 review 修复（并发部分，2 个独立 commit）。

### Commit 1: `fix(ui): serialize settings saves to prevent lost updates`

**问题**：设置页保存存在两类竞态：
1. 并发保存时，先返回的响应 `setSettings(persisted)` 会覆盖更新的乐观值，**用户变更被静默丢弃**（4 个高级开关在 saving 期间未禁用，窗口真实存在）；
2. `SetAutostart`（部分更新）与 `Update`（全量替换）交错时，全量载荷携带过期 `autostart=false`，会把刚持久化的自启配置覆盖回 false——**注册表已生效但配置被回滚**。

**修复**：
- 统一保存队列（`enqueueSave`，Promise 链串行化），`save`/`setAutostart`/`setAutoStartEngine`/配置迁移全部入队；
- `setAutostart`/`setAutoStartEngine` 入队前乐观更新（镜像后端"关 autostart 联动清 auto_start_engine"语义），后续全量载荷不再携带过期值；
- 成功写回改为 merge（`{...emptySettings, ...persisted, ...current}`），避免队列中后续操作的乐观值被回滚闪烁；
- 失败路径经 `settings.get()` 拉取服务端真值恢复；
- 配置迁移走同一队列，确认按钮受 `saving` 保护。

### Commit 2: `fix(dns): bound concurrent DoH dials per lookup to two`

**问题**：`PolicyAuto` 下 `resolveDoH` 对全部 5 个端点同时拨号，DoH 被阻断时（如防火墙封 443）连接与 goroutine 放大五倍，构成资源占用向量。

**修复**：信号量将单次查找的并发拨号限制为 2 路，保留端点竞速（前 2 个端点挂起时第 3 个最多等待一个 QueryTimeout，有界）。新增 `TestDoHRaceIsBounded`：阻塞 dial 模拟 + 原子并发峰值计数，断言拨号并发 ≤ 2。

## 验证

- 两个修复均通过 TDD（RED → GREEN → mutation；DoH 测试连跑 5 次无 flakiness）
- `go test ./engine/...`、`go test ./desktop/...`、`go vet`、前端 `tsc` + 生产构建全部通过

Refs #50
