### PR TITLE
Harden GitHub and CNB release pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,6 +275,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -337,18 +339,33 @@ jobs:
             -verify-public-key "$(tr -d '\r\n' < desktop/internal/services/update_manifest_ed25519_public_key.txt)"
           test "$(stat -c%s artifacts/latest.json.sig)" -eq 64
 
-      - name: Upload installer and signed manifest to GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            artifacts/HypoMux_Setup_*.exe
-            artifacts/latest.json
-            artifacts/latest.json.sig
-          fail_on_unmatched_files: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Preflight synchronized GitHub and CNB tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          expected_commit="$(git rev-parse HEAD^{commit})"
+          resolve_remote_tag_commit() {
+            local repository="$1"
+            local refs
+            local direct
+            local peeled
+            refs="$(git ls-remote "${repository}" "refs/tags/${tag}" "refs/tags/${tag}^{}" || true)"
+            direct="$(awk -v ref="refs/tags/${tag}" '$2 == ref {print $1; exit}' <<<"${refs}")"
+            peeled="$(awk -v ref="refs/tags/${tag}^{}" '$2 == ref {print $1; exit}' <<<"${refs}")"
+            if [[ -n "${peeled}" ]]; then printf '%s' "${peeled}"; else printf '%s' "${direct}"; fi
+          }
+          github_commit="$(resolve_remote_tag_commit origin)"
+          cnb_commit="$(resolve_remote_tag_commit https://cnb.cool/Hypostasis-Cat/HypoMux)"
+          if [[ -z "${github_commit}" || -z "${cnb_commit}" ||
+                "${github_commit}" != "${cnb_commit}" ||
+                "${github_commit}" != "${expected_commit}" ]]; then
+            echo "Release tag preflight failed: expected=${expected_commit} GitHub=${github_commit:-missing} CNB=${cnb_commit:-missing}."
+            exit 1
+          fi
+          echo "Release tag ${tag} is synchronized at ${expected_commit}."
 
-      - name: Ensure CNB Release and upload signed assets
+      - name: Ensure CNB Release and upload installer
         shell: bash
         env:
           CNB_TOKEN: ${{ secrets.CNB_TOKEN }}
@@ -362,32 +379,196 @@ jobs:
               git-cnb --repo=Hypostasis-Cat/HypoMux "$@"
           }
 
-          release_ready=false
-          for attempt in $(seq 1 20); do
-            if cnb release get -t "${tag}" >/dev/null 2>&1; then
-              release_ready=true
-              break
-            fi
-            if cnb release create -t "${tag}" -n "HypoMux ${version}" --make-latest true; then
-              release_ready=true
-              break
-            fi
-            echo "CNB tag or Release is not ready yet (attempt ${attempt}/20); retrying in 15 seconds."
-            sleep 15
-          done
-          if [[ "${release_ready}" != "true" ]]; then
-            echo "CNB Release ${tag} could not be found or created after waiting for tag mirroring."
-            exit 1
+          if ! cnb release get -t "${tag}" >/dev/null 2>&1; then
+            cnb release create -t "${tag}" -n "HypoMux ${version}" --make-latest true
           fi
           cnb release get -t "${tag}" >/dev/null
 
-          for asset in \
-            "artifacts/${{ steps.stage_release.outputs.installer_name }}" \
-            artifacts/latest.json \
-            artifacts/latest.json.sig
-          do
-            docker run --rm -e CNB_TOKEN \
-              -v "${PWD}:/workspace:ro" -w /workspace "${CNB_IMAGE}" \
-              git-cnb --repo=Hypostasis-Cat/HypoMux \
-              release asset-upload -t "${tag}" -f "${asset}"
-          done
+          installer="artifacts/${{ steps.stage_release.outputs.installer_name }}"
+          asset_url="https://cnb.cool/Hypostasis-Cat/HypoMux/-/releases/download/${tag}/$(basename "${installer}")"
+          existing="artifacts/cnb-existing-installer.exe"
+          status="$(curl --silent --show-error --location --output "${existing}" --write-out '%{http_code}' "${asset_url}" || true)"
+          case "${status}" in
+            200)
+              if ! cmp --silent "${installer}" "${existing}"; then
+                echo "CNB Release already contains a different installer with the same name."
+                exit 1
+              fi
+              echo "CNB installer already exists and is byte-identical; skipping upload."
+              ;;
+            404)
+              docker run --rm -e CNB_TOKEN \
+                -v "${PWD}:/workspace:ro" -w /workspace "${CNB_IMAGE}" \
+                git-cnb --repo=Hypostasis-Cat/HypoMux \
+                  release asset-upload -t "${tag}" -f "${installer}"
+              ;;
+            *)
+              echo "Unable to inspect the CNB installer before upload (HTTP ${status:-unknown})."
+              exit 1
+              ;;
+          esac
+
+      - name: Check existing GitHub installer
+        id: github_installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          installer="artifacts/${{ steps.stage_release.outputs.installer_name }}"
+          asset_url="https://github.com/Hypostasis-Cat/HypoMux/releases/download/${GITHUB_REF_NAME}/$(basename "${installer}")"
+          existing="artifacts/github-existing-installer.exe"
+          status="$(curl --silent --show-error --location --output "${existing}" --write-out '%{http_code}' "${asset_url}" || true)"
+          case "${status}" in
+            200)
+              if ! cmp --silent "${installer}" "${existing}"; then
+                echo "GitHub Release already contains a different installer with the same name."
+                exit 1
+              fi
+              echo "upload=false" >> "${GITHUB_OUTPUT}"
+              ;;
+            404)
+              echo "upload=true" >> "${GITHUB_OUTPUT}"
+              ;;
+            *)
+              echo "Unable to inspect the GitHub installer before upload (HTTP ${status:-unknown})."
+              exit 1
+              ;;
+          esac
+
+      - name: Upload installer to GitHub Release
+        if: steps.github_installer.outputs.upload == 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: artifacts/${{ steps.stage_release.outputs.installer_name }}
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify both Release installers are byte-identical
+        shell: bash
+        run: |
+          set -euo pipefail
+          installer="artifacts/${{ steps.stage_release.outputs.installer_name }}"
+          filename="$(basename "${installer}")"
+          verify_download() {
+            local label="$1"
+            local url="$2"
+            local destination="$3"
+            for attempt in $(seq 1 12); do
+              if curl --fail --silent --show-error --location --output "${destination}" "${url}" &&
+                 cmp --silent "${installer}" "${destination}"; then
+                echo "${label} installer matches the signed build."
+                return 0
+              fi
+              rm -f "${destination}"
+              sleep 5
+            done
+            echo "${label} installer did not become available or was not byte-identical."
+            return 1
+          }
+          verify_download GitHub \
+            "https://github.com/Hypostasis-Cat/HypoMux/releases/download/${GITHUB_REF_NAME}/${filename}" \
+            artifacts/verify-github-installer.exe
+          verify_download CNB \
+            "https://cnb.cool/Hypostasis-Cat/HypoMux/-/releases/download/${GITHUB_REF_NAME}/${filename}" \
+            artifacts/verify-cnb-installer.exe
+          sha256sum "${installer}" artifacts/verify-github-installer.exe artifacts/verify-cnb-installer.exe
+
+      - name: Publish signed update channel to GitHub and CNB
+        shell: bash
+        env:
+          CNB_TOKEN: ${{ secrets.CNB_TOKEN }}
+        run: |
+          set -euo pipefail
+          channel_ref="refs/heads/update-channel"
+          credential_file="$(mktemp)"
+          cleanup() {
+            git config --local --unset-all credential.helper >/dev/null 2>&1 || true
+            rm -f "${credential_file}"
+          }
+          trap cleanup EXIT
+          chmod 600 "${credential_file}"
+          git config --local credential.helper "store --file=${credential_file}"
+          printf 'protocol=https\nhost=cnb.cool\nusername=cnb\npassword=%s\n\n' "${CNB_TOKEN}" |
+            git credential approve
+          if git remote get-url cnb >/dev/null 2>&1; then
+            git remote set-url cnb https://cnb.cool/Hypostasis-Cat/HypoMux
+          else
+            git remote add cnb https://cnb.cool/Hypostasis-Cat/HypoMux
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          parent="$(git ls-remote origin "${channel_ref}" | awk 'NR == 1 {print $1}')"
+          if [[ -n "${parent}" ]]; then
+            git fetch --no-tags origin "${channel_ref}:refs/remotes/origin/update-channel"
+          fi
+
+          manifest_blob="$(git hash-object -w artifacts/latest.json)"
+          signature_blob="$(git hash-object -w artifacts/latest.json.sig)"
+          channel_tree="$(printf '100644 blob %s\tlatest.json\n100644 blob %s\tlatest.json.sig\n' \
+            "${manifest_blob}" "${signature_blob}" | git mktree)"
+          if [[ -n "${parent}" && "$(git rev-parse "${parent}^{tree}")" == "${channel_tree}" ]]; then
+            channel_commit="${parent}"
+          elif [[ -n "${parent}" ]]; then
+            channel_commit="$(printf 'Update channel for %s\n' "${GITHUB_REF_NAME}" |
+              git commit-tree "${channel_tree}" -p "${parent}")"
+          else
+            channel_commit="$(printf 'Initialize update channel for %s\n' "${GITHUB_REF_NAME}" |
+              git commit-tree "${channel_tree}")"
+          fi
+
+          git push origin "${channel_commit}:${channel_ref}"
+          git push cnb "${channel_commit}:${channel_ref}"
+          github_channel="$(git ls-remote origin "${channel_ref}" | awk 'NR == 1 {print $1}')"
+          cnb_channel="$(git ls-remote cnb "${channel_ref}" | awk 'NR == 1 {print $1}')"
+          if [[ "${github_channel}" != "${channel_commit}" || "${cnb_channel}" != "${channel_commit}" ]]; then
+            echo "Update channel synchronization failed: expected=${channel_commit} GitHub=${github_channel:-missing} CNB=${cnb_channel:-missing}."
+            exit 1
+          fi
+          echo "Update channel synchronized at ${channel_commit}."
+
+      - name: Verify both raw update channels and Ed25519 signature
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p channel-verify
+          fetch_exact() {
+            local label="$1"
+            local url="$2"
+            local expected="$3"
+            local destination="$4"
+            for attempt in $(seq 1 12); do
+              if curl --fail --silent --show-error --location --output "${destination}" "${url}" &&
+                 cmp --silent "${expected}" "${destination}"; then
+                echo "${label} is byte-identical."
+                return 0
+              fi
+              rm -f "${destination}"
+              sleep 5
+            done
+            echo "${label} did not match the published update channel."
+            return 1
+          }
+          fetch_exact "GitHub latest.json" \
+            https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json \
+            artifacts/latest.json channel-verify/github-latest.json
+          fetch_exact "GitHub latest.json.sig" \
+            https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json.sig \
+            artifacts/latest.json.sig channel-verify/github-latest.json.sig
+          fetch_exact "CNB latest.json" \
+            https://cnb.cool/Hypostasis-Cat/HypoMux/-/git/raw/update-channel/latest.json \
+            artifacts/latest.json channel-verify/cnb-latest.json
+          fetch_exact "CNB latest.json.sig" \
+            https://cnb.cool/Hypostasis-Cat/HypoMux/-/git/raw/update-channel/latest.json.sig \
+            artifacts/latest.json.sig channel-verify/cnb-latest.json.sig
+          public_key="$(tr -d '\r\n' < desktop/internal/services/update_manifest_ed25519_public_key.txt)"
+          go -C desktop run ./cmd/update-manifest-sign \
+            -verify-only \
+            -input ../channel-verify/github-latest.json \
+            -output ../channel-verify/github-latest.json.sig \
+            -verify-public-key "${public_key}"
+          go -C desktop run ./cmd/update-manifest-sign \
+            -verify-only \
+            -input ../channel-verify/cnb-latest.json \
+            -output ../channel-verify/cnb-latest.json.sig \
+            -verify-public-key "${public_key}"

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -23,10 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate and create tag
+      - name: Validate and synchronize release tag
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          CNB_TOKEN: ${{ secrets.CNB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -35,12 +36,83 @@ jobs:
             exit 1
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "Tag $RELEASE_TAG already exists and will not be moved."
+          expected_commit="$(git rev-parse HEAD^{commit})"
+          credential_file="$(mktemp)"
+          cleanup() {
+            git config --local --unset-all credential.helper >/dev/null 2>&1 || true
+            rm -f "${credential_file}"
+          }
+          trap cleanup EXIT
+          chmod 600 "${credential_file}"
+          git config --local credential.helper "store --file=${credential_file}"
+          printf 'protocol=https\nhost=cnb.cool\nusername=cnb\npassword=%s\n\n' "${CNB_TOKEN}" |
+            git credential approve
+
+          if git remote get-url cnb >/dev/null 2>&1; then
+            git remote set-url cnb https://cnb.cool/Hypostasis-Cat/HypoMux
+          else
+            git remote add cnb https://cnb.cool/Hypostasis-Cat/HypoMux
+          fi
+
+          resolve_remote_tag_commit() {
+            local remote="$1"
+            local refs
+            local direct
+            local peeled
+            refs="$(git ls-remote "${remote}" "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" || true)"
+            direct="$(awk -v ref="refs/tags/${RELEASE_TAG}" '$2 == ref {print $1; exit}' <<<"${refs}")"
+            peeled="$(awk -v ref="refs/tags/${RELEASE_TAG}^{}" '$2 == ref {print $1; exit}' <<<"${refs}")"
+            if [[ -n "${peeled}" ]]; then
+              printf '%s' "${peeled}"
+            else
+              printf '%s' "${direct}"
+            fi
+          }
+
+          github_commit="$(resolve_remote_tag_commit origin)"
+          if [[ -z "${github_commit}" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            if git rev-parse --verify "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+              local_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+              if [[ "${local_commit}" != "${expected_commit}" ]]; then
+                echo "Local tag ${RELEASE_TAG} points to ${local_commit}, expected ${expected_commit}; refusing to move it."
+                exit 1
+              fi
+            else
+              git tag --annotate "${RELEASE_TAG}" "${expected_commit}" --message "Release ${RELEASE_TAG}"
+            fi
+            git push origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            github_commit="$(resolve_remote_tag_commit origin)"
+          elif [[ "${github_commit}" != "${expected_commit}" ]]; then
+            echo "GitHub tag ${RELEASE_TAG} points to ${github_commit}, expected ${expected_commit}; refusing to move it."
             exit 1
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag --annotate "$RELEASE_TAG" --message "Release $RELEASE_TAG"
-          git push origin "refs/tags/$RELEASE_TAG"
+          if ! git rev-parse --verify "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          fi
+          local_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          if [[ "${local_commit}" != "${expected_commit}" ]]; then
+            echo "Fetched GitHub tag ${RELEASE_TAG} points to ${local_commit}, expected ${expected_commit}."
+            exit 1
+          fi
+
+          cnb_commit="$(resolve_remote_tag_commit cnb)"
+          if [[ -z "${cnb_commit}" ]]; then
+            git push cnb "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            cnb_commit="$(resolve_remote_tag_commit cnb)"
+          elif [[ "${cnb_commit}" != "${expected_commit}" ]]; then
+            echo "CNB tag ${RELEASE_TAG} points to ${cnb_commit}, expected ${expected_commit}; refusing to move it."
+            exit 1
+          fi
+
+          github_commit="$(resolve_remote_tag_commit origin)"
+          cnb_commit="$(resolve_remote_tag_commit cnb)"
+          if [[ "${github_commit}" != "${expected_commit}" ||
+                "${cnb_commit}" != "${expected_commit}" ||
+                "${github_commit}" != "${cnb_commit}" ]]; then
+            echo "Release tag verification failed: expected=${expected_commit} GitHub=${github_commit:-missing} CNB=${cnb_commit:-missing}."
+            exit 1
+          fi
+          echo "Release tag ${RELEASE_TAG} is synchronized at ${expected_commit}."

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -65,7 +65,7 @@ jobs:
             fi
           }
           github_commit="$(resolve_tag_commit https://github.com/Hypostasis-Cat/HypoMux.git)"
-          cnb_commit="$(resolve_tag_commit https://cnb.cool/Hypostasis-Cat/HypoMux.git)"
+          cnb_commit="$(resolve_tag_commit https://cnb.cool/Hypostasis-Cat/HypoMux)"
           if [[ -z "${github_commit}" || -z "${cnb_commit}" ]]; then
             echo "Release tag ${RELEASE_TAG} is missing from GitHub or CNB."
             exit 1
@@ -84,7 +84,58 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
+          credential_file="$(mktemp)"
+          cleanup() {
+            git config --local --unset-all credential.helper >/dev/null 2>&1 || true
+            rm -f "${credential_file}"
+          }
+          trap cleanup EXIT
+          chmod 600 "${credential_file}"
+          git config --local credential.helper "store --file=${credential_file}"
+          printf 'protocol=https\nhost=cnb.cool\nusername=cnb\npassword=%s\n\n' "${CNB_TOKEN}" |
+            git credential approve
+          git ls-remote https://cnb.cool/Hypostasis-Cat/HypoMux refs/heads/main >/dev/null
           docker run --rm -e CNB_TOKEN "${CNB_IMAGE}" \
             git-cnb --repo=Hypostasis-Cat/HypoMux \
             release get -t "${RELEASE_TAG}" >/dev/null
           echo "CNB Release ${RELEASE_TAG} is readable; no assets were created or uploaded."
+
+      - name: Verify existing signed update channel is readable and identical
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel_ref=refs/heads/update-channel
+          github_channel="$(git ls-remote https://github.com/Hypostasis-Cat/HypoMux.git "${channel_ref}" | awk 'NR == 1 {print $1}')"
+          cnb_channel="$(git ls-remote https://cnb.cool/Hypostasis-Cat/HypoMux "${channel_ref}" | awk 'NR == 1 {print $1}')"
+          if [[ -z "${github_channel}" && -z "${cnb_channel}" ]]; then
+            echo "update-channel does not exist yet; raw endpoint verification is not applicable."
+            exit 0
+          fi
+          if [[ -z "${github_channel}" || -z "${cnb_channel}" || "${github_channel}" != "${cnb_channel}" ]]; then
+            echo "update-channel refs differ: GitHub=${github_channel:-missing} CNB=${cnb_channel:-missing}."
+            exit 1
+          fi
+
+          mkdir -p smoke/channel
+          curl --fail --silent --show-error --location \
+            --output smoke/channel/github-latest.json \
+            https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json
+          curl --fail --silent --show-error --location \
+            --output smoke/channel/github-latest.json.sig \
+            https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json.sig
+          curl --fail --silent --show-error --location \
+            --output smoke/channel/cnb-latest.json \
+            https://cnb.cool/Hypostasis-Cat/HypoMux/-/git/raw/update-channel/latest.json
+          curl --fail --silent --show-error --location \
+            --output smoke/channel/cnb-latest.json.sig \
+            https://cnb.cool/Hypostasis-Cat/HypoMux/-/git/raw/update-channel/latest.json.sig
+          cmp --silent smoke/channel/github-latest.json smoke/channel/cnb-latest.json
+          cmp --silent smoke/channel/github-latest.json.sig smoke/channel/cnb-latest.json.sig
+
+          public_key="$(tr -d '\r\n' < desktop/internal/services/update_manifest_ed25519_public_key.txt)"
+          go -C desktop run ./cmd/update-manifest-sign \
+            -verify-only \
+            -input ../smoke/channel/github-latest.json \
+            -output ../smoke/channel/github-latest.json.sig \
+            -verify-public-key "${public_key}"
+          echo "Both raw update channels are byte-identical and the Ed25519 signature is valid."

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ HypoMux 聚合的是多个独立连接，而不是把单条 TCP 连接拆成多�
 
 HypoMux 衷心感谢 SignPath 与 SignPath Foundation 对开源软件的支持，帮助我们为 Windows 用户提供更安全、可信的下载体验。
 
-HypoMux 的官方 Windows 发布版本均由此仓库的 GitHub Actions 构建，并提交至 SignPath 进行代码签名。[GitHub Releases](https://github.com/Hypostasis-Cat/HypoMux/releases/latest)是权威发布源，[腾讯 CNB Release](https://cnb.cool/Hypostasis-Cat/HypoMux/-/releases/latest)是面向中国大陆的官方镜像；两处发布同一份签名安装包及 Ed25519 签名更新清单。客户端会先验证清单签名、安装包大小与 SHA-256，再验证 Windows Authenticode 签名；下载安装后请确认发布者显示为 **SignPath Foundation**。
+HypoMux 的官方 Windows 发布版本均由此仓库的 GitHub Actions 构建，并提交至 SignPath 进行代码签名。[GitHub Releases](https://github.com/Hypostasis-Cat/HypoMux/releases/latest)是权威公开发布页，[腾讯 CNB Release](https://cnb.cool/Hypostasis-Cat/HypoMux/-/releases/latest)是面向中国大陆的官方镜像；两处只分发同一份 SignPath 签名安装包。自动更新元数据通过独立的 signed update channel 分发并使用 Ed25519 验证，客户端随后校验安装包大小、SHA-256 与 Windows Authenticode 签名。下载安装后请确认发布者显示为 **SignPath Foundation**。
 
 ### 团队角色
 
@@ -62,7 +62,7 @@ HypoMux 的官方 Windows 发布版本均由此仓库的 GitHub Actions 构建�
 
 ### 隐私政策
 
-HypoMux 不收集、出售或上传个人数据及遥测信息。程序仅会在用户或软件操作者请求相应功能时与其他网络系统通信：转发用户选择的网络流量、从官方 GitHub 或 CNB Release 源检查及下载安装更新，以及在启用虚拟网卡模式后进行网络连通性验证。
+HypoMux 不收集、出售或上传个人数据及遥测信息。程序仅会在用户或软件操作者请求相应功能时与其他网络系统通信：转发用户选择的网络流量、从官方 signed update channel 检查更新、从 GitHub 或 CNB Release 下载安装包，以及在启用虚拟网卡模式后进行网络连通性验证。
 
 ---
 
@@ -213,7 +213,7 @@ wails3 task windows:package
 ```
 
 完整发布流程以 [`.github/workflows/build.yml`](.github/workflows/build.yml) 为准。
-正式发布前可手动运行 `Release Trust Smoke Test` 工作流，只读核对更新清单私钥与客户端公钥、GitHub/CNB Tag 提交以及 CNB Release 访问权限；该检查不会创建 Release 或上传资产。
+正式发布前可手动运行 `Release Trust Smoke Test` 工作流，只读核对更新清单密钥、GitHub/CNB Tag、CNB Release 访问权限及已有 signed update channel；该检查不会创建 Release、上传资产或修改更新通道。
 
 ##  特别鸣谢 / Acknowledgments
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -53,7 +53,7 @@ Version 2.5.3 completes the desktop migration from the former Python/Qt and tran
 
 HypoMux is sincerely grateful to SignPath and the SignPath Foundation for supporting open-source software and helping us deliver a safer Windows download experience.
 
-The official Windows releases of HypoMux are built from this repository through GitHub Actions and submitted to SignPath for code signing. [GitHub Releases](https://github.com/Hypostasis-Cat/HypoMux/releases/latest) is the authoritative release source, while [Tencent CNB Release](https://cnb.cool/Hypostasis-Cat/HypoMux/-/releases/latest) is the official mainland China mirror; both distribute the same signed installer. Verify that signed releases show **SignPath Foundation** as the publisher.
+The official Windows releases of HypoMux are built from this repository through GitHub Actions and submitted to SignPath for code signing. [GitHub Releases](https://github.com/Hypostasis-Cat/HypoMux/releases/latest) is the authoritative public release page, while [Tencent CNB Release](https://cnb.cool/Hypostasis-Cat/HypoMux/-/releases/latest) is the official mainland China mirror; both distribute only the same SignPath-signed installer. Automatic update metadata is delivered through a separate signed update channel and verified with Ed25519, followed by installer size, SHA-256, and Windows Authenticode verification. Signed installers should show **SignPath Foundation** as the publisher.
 
 ### Team roles
 
@@ -62,7 +62,7 @@ The official Windows releases of HypoMux are built from this repository through 
 
 ### Privacy policy
 
-HypoMux does not collect, sell, or upload personal data or telemetry. The program contacts other networked systems only to perform functionality requested by the user or the person operating it: forwarding the user's selected network traffic, checking or downloading updates from the official GitHub or CNB Release source, and validating connectivity after Virtual NIC mode has been enabled.
+HypoMux does not collect, sell, or upload personal data or telemetry. The program contacts other networked systems only to perform functionality requested by the user or the person operating it: forwarding selected network traffic, checking the official signed update channel, downloading installers from GitHub or CNB Release, and validating connectivity after Virtual NIC mode has been enabled.
 
 ---
 
@@ -213,6 +213,7 @@ wails3 task windows:package
 ```
 
 See [`.github/workflows/build.yml`](.github/workflows/build.yml) for the complete release pipeline.
+Before a production release, the read-only `Release Trust Smoke Test` workflow can validate the update signing key, synchronized GitHub/CNB tags, CNB Release access, and any existing signed update channel without creating a Release, uploading assets, or modifying the channel.
 
 ##  Acknowledgments & Contributors
 

--- a/desktop/cmd/update-manifest-sign/main.go
+++ b/desktop/cmd/update-manifest-sign/main.go
@@ -16,7 +16,19 @@ func main() {
 	inputPath := flag.String("input", "", "path to the exact manifest bytes to sign")
 	outputPath := flag.String("output", "", "path for the raw Ed25519 signature")
 	verificationKey := flag.String("verify-public-key", "", "optional base64 Ed25519 public key that must verify the signature")
+	verifyOnly := flag.Bool("verify-only", false, "verify an existing signature without reading the private key")
 	flag.Parse()
+	if *verifyOnly {
+		if *verificationKey == "" {
+			fmt.Fprintln(os.Stderr, "verify update manifest signature: -verify-public-key is required with -verify-only")
+			os.Exit(1)
+		}
+		if err := verifyManifestSignature(*inputPath, *outputPath, *verificationKey); err != nil {
+			fmt.Fprintln(os.Stderr, "verify update manifest signature:", err)
+			os.Exit(1)
+		}
+		return
+	}
 	if err := signManifest(*inputPath, *outputPath, os.Getenv(privateKeyEnvironment)); err != nil {
 		fmt.Fprintln(os.Stderr, "sign update manifest:", err)
 		os.Exit(1)

--- a/desktop/installer_layout_test.go
+++ b/desktop/installer_layout_test.go
@@ -264,7 +264,7 @@ func TestReleasePublishesLegacyUpdaterCompatibleInstallerName(t *testing.T) {
 	}
 }
 
-func TestReleasePublishesOneSignedInstallerAndManifestToBothMirrors(t *testing.T) {
+func TestReleasePublishesOneSignedInstallerThenUpdatesSignedChannel(t *testing.T) {
 	data, err := os.ReadFile("../.github/workflows/build.yml")
 	if err != nil {
 		t.Fatal(err)
@@ -282,8 +282,13 @@ func TestReleasePublishesOneSignedInstallerAndManifestToBothMirrors(t *testing.T
 		`secrets.CNB_TOKEN`,
 		`cnb release get -t "${tag}"`,
 		`cnb release create -t "${tag}"`,
-		`release asset-upload -t "${tag}"`,
+		`release asset-upload -t "${tag}" -f "${installer}"`,
 		`HYPOMUX_SIGNED_INSTALLER_TEST`,
+		`git push origin "${channel_commit}:${channel_ref}"`,
+		`git push cnb "${channel_commit}:${channel_ref}"`,
+		`https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json`,
+		`https://cnb.cool/Hypostasis-Cat/HypoMux/-/git/raw/update-channel/latest.json`,
+		`-verify-only`,
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Fatalf("dual-source release workflow is missing %q", required)
@@ -294,6 +299,53 @@ func TestReleasePublishesOneSignedInstallerAndManifestToBothMirrors(t *testing.T
 	}
 	if strings.Contains(workflow, `docker.cnb.cool/looc/git-cnb:1.2.0`) {
 		t.Fatal("release workflow uses a nonexistent mutable git-cnb image tag")
+	}
+	if strings.Contains(workflow, `files: artifacts/latest.json`) ||
+		strings.Contains(workflow, `release asset-upload -t "${tag}" -f artifacts/latest.json`) {
+		t.Fatal("release workflow exposes update metadata as Release assets")
+	}
+	if strings.Contains(workflow, `for attempt in $(seq 1 20)`) ||
+		strings.Contains(workflow, `retrying in 15 seconds`) {
+		t.Fatal("release workflow still waits for asynchronous CNB tag mirroring")
+	}
+	verifyAssets := strings.Index(workflow, `- name: Verify both Release installers are byte-identical`)
+	publishChannel := strings.Index(workflow, `- name: Publish signed update channel to GitHub and CNB`)
+	if verifyAssets < 0 || publishChannel < 0 || publishChannel < verifyAssets {
+		t.Fatal("update-channel must be published only after both Release installers are verified")
+	}
+}
+
+func TestCreateReleaseTagSynchronizesCNBIdempotently(t *testing.T) {
+	data, err := os.ReadFile("../.github/workflows/create-release-tag.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	for _, required := range []string{
+		`CNB_TOKEN: ${{ secrets.CNB_TOKEN }}`,
+		`username=cnb`,
+		`git credential approve`,
+		`git remote add cnb https://cnb.cool/Hypostasis-Cat/HypoMux`,
+		`github_commit="$(resolve_remote_tag_commit origin)"`,
+		`cnb_commit="$(resolve_remote_tag_commit cnb)"`,
+		`git push cnb "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"`,
+		`if [[ -z "${github_commit}" ]]`,
+		`elif [[ "${github_commit}" != "${expected_commit}" ]]`,
+		`elif [[ "${cnb_commit}" != "${expected_commit}" ]]`,
+		`"${github_commit}" != "${cnb_commit}"`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("release tag workflow is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		`https://cnb:${CNB_TOKEN}@`,
+		`${CNB_TOKEN}@cnb.cool`,
+		`already exists and will not be moved`,
+	} {
+		if strings.Contains(workflow, forbidden) {
+			t.Fatalf("release tag workflow is not safely rerunnable: found %q", forbidden)
+		}
 	}
 }
 
@@ -311,6 +363,11 @@ func TestReleaseTrustSmokeWorkflowIsReadOnly(t *testing.T) {
 		`cnb_commit`,
 		`release get -t "${RELEASE_TAG}"`,
 		`secrets.CNB_TOKEN`,
+		`docker.cnb.cool/looc/git-cnb@sha256:c254172bb9d6025733a0e2991b4a99af8c46aeedcadcb468788ef5a0dc00275c`,
+		`refs/heads/update-channel`,
+		`https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json`,
+		`https://cnb.cool/Hypostasis-Cat/HypoMux/-/git/raw/update-channel/latest.json`,
+		`-verify-only`,
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Fatalf("release trust smoke workflow is missing %q", required)
@@ -321,6 +378,8 @@ func TestReleaseTrustSmokeWorkflowIsReadOnly(t *testing.T) {
 		`release create`,
 		`actions/upload-artifact`,
 		`action-gh-release`,
+		`git push`,
+		`git commit-tree`,
 	} {
 		if strings.Contains(workflow, forbidden) {
 			t.Fatalf("release trust smoke workflow must be read-only: found %q", forbidden)

--- a/desktop/internal/services/updater.go
+++ b/desktop/internal/services/updater.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -26,14 +25,12 @@ import (
 
 const (
 	CurrentVersion           = "2.5.7"
-	latestReleaseAPI         = "https://api.github.com/repos/Hypostasis-Cat/HypoMux/releases/latest"
-	releasesFeedURL          = "https://github.com/Hypostasis-Cat/HypoMux/releases.atom"
 	githubRepositoryURL      = "https://github.com/Hypostasis-Cat/HypoMux"
 	releaseDownloadURL       = githubRepositoryURL + "/releases/download/"
-	githubLatestManifestURL  = githubRepositoryURL + "/releases/latest/download/latest.json"
+	githubLatestManifestURL  = "https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json"
 	cnbRepositoryURL         = "https://cnb.cool/Hypostasis-Cat/HypoMux"
 	cnbDownloadURL           = cnbRepositoryURL + "/-/releases/download/"
-	cnbLatestManifestURL     = cnbRepositoryURL + "/-/releases/latest/download/latest.json"
+	cnbLatestManifestURL     = cnbRepositoryURL + "/-/git/raw/update-channel/latest.json"
 	updateManifestName       = "latest.json"
 	maxUpdateManifestSize    = 2 << 20
 	maxManifestSignatureSize = 1024
@@ -133,13 +130,12 @@ func (s *UpdaterService) Check() (UpdateCheckResult, error) {
 		check func(context.Context) (ReleaseInfo, error)
 	}
 	sources := []metadataSource{
-		{name: "GitHub manifest", check: func(ctx context.Context) (ReleaseInfo, error) {
-			return s.checkUpdateManifest(ctx, githubLatestManifestURL)
-		}},
 		{name: "CNB manifest", check: func(ctx context.Context) (ReleaseInfo, error) {
 			return s.checkUpdateManifest(ctx, cnbLatestManifestURL)
 		}},
-		{name: "GitHub API tag discovery", check: s.checkGitHubAPI},
+		{name: "GitHub manifest", check: func(ctx context.Context) (ReleaseInfo, error) {
+			return s.checkUpdateManifest(ctx, githubLatestManifestURL)
+		}},
 	}
 	type sourceResult struct {
 		index   int
@@ -160,7 +156,7 @@ func (s *UpdaterService) Check() (UpdateCheckResult, error) {
 		ordered[result.index] = result
 	}
 	candidates := make([]ReleaseInfo, 0, len(sources))
-	errorsBySource := make([]string, 0, len(sources)+1)
+	errorsBySource := make([]string, 0, len(sources))
 	for index, result := range ordered {
 		if result.err != nil {
 			errorsBySource = append(errorsBySource, sources[index].name+": "+result.err.Error())
@@ -169,14 +165,7 @@ func (s *UpdaterService) Check() (UpdateCheckResult, error) {
 		candidates = append(candidates, result.release)
 	}
 	if len(candidates) == 0 {
-		feedCtx, feedCancel := context.WithTimeout(context.Background(), updateMetadataTimeout)
-		feedRelease, feedErr := s.checkGitHubReleaseFeed(feedCtx)
-		feedCancel()
-		if feedErr != nil {
-			errorsBySource = append(errorsBySource, "GitHub Atom tag discovery: "+feedErr.Error())
-			return UpdateCheckResult{}, errors.New(strings.Join(errorsBySource, "；"))
-		}
-		candidates = append(candidates, feedRelease)
+		return UpdateCheckResult{}, errors.New(strings.Join(errorsBySource, "；"))
 	}
 
 	release, err := selectLatestRelease(candidates)
@@ -190,38 +179,8 @@ func (s *UpdaterService) Check() (UpdateCheckResult, error) {
 	}, nil
 }
 
-func (s *UpdaterService) checkGitHubAPI(ctx context.Context) (ReleaseInfo, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseAPI, nil)
-	if err != nil {
-		return ReleaseInfo{}, err
-	}
-	request.Header.Set("Accept", "application/vnd.github+json")
-	request.Header.Set("User-Agent", "HypoMux-Updater")
-	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	response, err := s.client.Do(request)
-	if err != nil {
-		return ReleaseInfo{}, errors.New("无法连接 GitHub，请检查网络后重试")
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return ReleaseInfo{}, fmt.Errorf("GitHub HTTP %d", response.StatusCode)
-	}
-	var payload struct {
-		TagName string `json:"tag_name"`
-	}
-	decoder := json.NewDecoder(io.LimitReader(response.Body, 2<<20))
-	if err := decoder.Decode(&payload); err != nil {
-		return ReleaseInfo{}, errors.New("GitHub 返回了无效的更新信息")
-	}
-	tagName := normalizeTagName(payload.TagName)
-	if versionKey(tagName) == nil {
-		return ReleaseInfo{}, errors.New("GitHub 最新发布的版本号无效")
-	}
-	return s.checkTaggedUpdateManifests(ctx, tagName)
-}
-
 func (s *UpdaterService) checkUpdateManifest(ctx context.Context, manifestURL string) (ReleaseInfo, error) {
-	if err := validateUpdateURL(manifestURL); err != nil {
+	if err := validateUpdateMetadataURL(manifestURL); err != nil {
 		return ReleaseInfo{}, errors.New("更新 manifest 地址无效")
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
@@ -246,7 +205,7 @@ func (s *UpdaterService) checkUpdateManifest(ctx context.Context, manifestURL st
 		return ReleaseInfo{}, errors.New("更新 manifest 超过大小限制")
 	}
 	signatureURL := manifestURL + ".sig"
-	if err := validateUpdateURL(signatureURL); err != nil {
+	if err := validateUpdateMetadataURL(signatureURL); err != nil {
 		return ReleaseInfo{}, errors.New("更新 manifest 签名地址无效")
 	}
 	signatureRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, signatureURL, nil)
@@ -294,51 +253,6 @@ func mustUpdateManifestPublicKey() ed25519.PublicKey {
 		panic("invalid embedded update manifest public key")
 	}
 	return ed25519.PublicKey(key)
-}
-
-func (s *UpdaterService) checkTaggedUpdateManifests(ctx context.Context, tagName string) (ReleaseInfo, error) {
-	tagName = normalizeTagName(tagName)
-	if versionKey(tagName) == nil {
-		return ReleaseInfo{}, errors.New("发现的更新标签无效")
-	}
-	manifestURLs := []string{
-		releaseDownloadURL + tagName + "/" + updateManifestName,
-		cnbDownloadURL + tagName + "/" + updateManifestName,
-	}
-	type manifestResult struct {
-		index   int
-		release ReleaseInfo
-		err     error
-	}
-	results := make(chan manifestResult, len(manifestURLs))
-	for index, manifestURL := range manifestURLs {
-		go func(index int, manifestURL string) {
-			release, err := s.checkUpdateManifest(ctx, manifestURL)
-			results <- manifestResult{index: index, release: release, err: err}
-		}(index, manifestURL)
-	}
-	ordered := make([]manifestResult, len(manifestURLs))
-	for range manifestURLs {
-		result := <-results
-		ordered[result.index] = result
-	}
-	candidates := make([]ReleaseInfo, 0, len(manifestURLs))
-	failures := make([]string, 0, len(manifestURLs))
-	for index, result := range ordered {
-		if result.err != nil {
-			failures = append(failures, manifestURLs[index]+": "+result.err.Error())
-			continue
-		}
-		if !sameVersion(result.release.TagName, tagName) {
-			failures = append(failures, manifestURLs[index]+": manifest 版本与发现的标签不一致")
-			continue
-		}
-		candidates = append(candidates, result.release)
-	}
-	if len(candidates) == 0 {
-		return ReleaseInfo{}, errors.New(strings.Join(failures, "；"))
-	}
-	return selectLatestRelease(candidates)
 }
 
 func ensureJSONEOF(decoder *json.Decoder) error {
@@ -412,19 +326,8 @@ func selectLatestRelease(candidates []ReleaseInfo) (ReleaseInfo, error) {
 		if !sameVersion(candidate.TagName, latest.TagName) {
 			continue
 		}
-		candidateDigest, candidateDigestErr := normalizeSHA256(candidate.InstallerDigest)
-		latestDigest, latestDigestErr := normalizeSHA256(latest.InstallerDigest)
-		if candidate.InstallerName != latest.InstallerName ||
-			candidate.InstallerSize != latest.InstallerSize ||
-			candidateDigestErr != nil || latestDigestErr != nil || candidateDigest != latestDigest {
-			return ReleaseInfo{}, errors.New("官方更新源对同一版本返回了不一致的安装包元数据")
-		}
-		merged.InstallerURLs = mergeMirrorURLs(merged.InstallerURLs, candidate.InstallerURLs)
-		if merged.Name == "" {
-			merged.Name = candidate.Name
-		}
-		if merged.Notes == "" {
-			merged.Notes = candidate.Notes
+		if !sameReleaseMetadata(candidate, latest) {
+			return ReleaseInfo{}, errors.New("官方更新源对同一版本返回了不一致的元数据")
 		}
 	}
 	if err := validateReleaseInfo(merged); err != nil {
@@ -433,55 +336,19 @@ func selectLatestRelease(candidates []ReleaseInfo) (ReleaseInfo, error) {
 	return merged, nil
 }
 
-func (s *UpdaterService) checkGitHubReleaseFeed(ctx context.Context) (ReleaseInfo, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesFeedURL, nil)
-	if err != nil {
-		return ReleaseInfo{}, err
+func sameReleaseMetadata(left ReleaseInfo, right ReleaseInfo) bool {
+	if left.TagName != right.TagName || left.Name != right.Name || left.Notes != right.Notes ||
+		left.PageURL != right.PageURL || left.InstallerName != right.InstallerName ||
+		left.InstallerSize != right.InstallerSize || left.InstallerDigest != right.InstallerDigest ||
+		len(left.InstallerURLs) != len(right.InstallerURLs) {
+		return false
 	}
-	request.Header.Set("Accept", "application/atom+xml, application/xml;q=0.9")
-	request.Header.Set("User-Agent", "HypoMux-Updater")
-	response, err := s.client.Do(request)
-	if err != nil {
-		return ReleaseInfo{}, errors.New("无法连接 GitHub 发布订阅")
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return ReleaseInfo{}, fmt.Errorf("GitHub 发布订阅 HTTP %d", response.StatusCode)
-	}
-	var feed struct {
-		Entries []struct {
-			Links []struct {
-				Rel  string `xml:"rel,attr"`
-				Href string `xml:"href,attr"`
-			} `xml:"link"`
-		} `xml:"entry"`
-	}
-	decoder := xml.NewDecoder(io.LimitReader(response.Body, 2<<20))
-	if err := decoder.Decode(&feed); err != nil {
-		return ReleaseInfo{}, errors.New("GitHub 返回了无效的发布订阅")
-	}
-	if len(feed.Entries) == 0 {
-		return ReleaseInfo{}, errors.New("GitHub 发布订阅中没有版本")
-	}
-	entry := feed.Entries[0]
-	pageURL := ""
-	for _, link := range entry.Links {
-		if strings.TrimSpace(link.Rel) == "" || strings.EqualFold(strings.TrimSpace(link.Rel), "alternate") {
-			pageURL = strings.TrimSpace(link.Href)
-			if pageURL != "" {
-				break
-			}
+	for index := range left.InstallerURLs {
+		if left.InstallerURLs[index] != right.InstallerURLs[index] {
+			return false
 		}
 	}
-	if err := validateUpdateURL(pageURL); err != nil {
-		return ReleaseInfo{}, errors.New("GitHub 发布订阅中的发布页地址无效")
-	}
-	parsedPage, _ := url.Parse(pageURL)
-	tagName := strings.TrimPrefix(strings.TrimSpace(parsedPage.Path), "/Hypostasis-Cat/HypoMux/releases/tag/")
-	if tagName == "" || strings.Contains(tagName, "/") || versionKey(tagName) == nil {
-		return ReleaseInfo{}, errors.New("GitHub 发布订阅中的版本号无效")
-	}
-	return s.checkTaggedUpdateManifests(ctx, tagName)
+	return true
 }
 
 func (s *UpdaterService) Download(release ReleaseInfo) (string, error) {
@@ -646,38 +513,20 @@ func (w *updateProgressWriter) Write(data []byte) (int, error) {
 	return count, err
 }
 
-func validateUpdateURL(value string) error {
+func validateUpdateMetadataURL(value string) error {
+	if value == githubLatestManifestURL || value == githubLatestManifestURL+".sig" ||
+		value == cnbLatestManifestURL || value == cnbLatestManifestURL+".sig" {
+		return nil
+	}
+	return errors.New("必须使用 HypoMux 官方 signed update channel 地址")
+}
+
+func validateInstallerMirrorURL(value string, tagName string, installerName string) error {
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Scheme != "https" || parsed.User != nil || parsed.Opaque != "" ||
 		parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" ||
 		parsed.ForceQuery || parsed.Path == "" {
-		return errors.New("必须使用官方 HTTPS 更新地址")
-	}
-	if parsed.Host != "github.com" && parsed.Host != "cnb.cool" {
-		return errors.New("必须使用 HypoMux 官方 GitHub 或 CNB Release 地址")
-	}
-	path := parsed.Path
-	switch {
-	case parsed.Host == "github.com" &&
-		(strings.HasPrefix(path, "/Hypostasis-Cat/HypoMux/releases/tag/") ||
-			strings.HasPrefix(path, "/Hypostasis-Cat/HypoMux/releases/download/") ||
-			path == "/Hypostasis-Cat/HypoMux/releases/latest/download/latest.json" ||
-			path == "/Hypostasis-Cat/HypoMux/releases/latest/download/latest.json.sig"):
-		return nil
-	case parsed.Host == "cnb.cool" &&
-		(strings.HasPrefix(path, "/Hypostasis-Cat/HypoMux/-/releases/tag/") ||
-			strings.HasPrefix(path, "/Hypostasis-Cat/HypoMux/-/releases/download/") ||
-			path == "/Hypostasis-Cat/HypoMux/-/releases/latest/download/latest.json" ||
-			path == "/Hypostasis-Cat/HypoMux/-/releases/latest/download/latest.json.sig"):
-		return nil
-	default:
-		return errors.New("必须使用 HypoMux 官方 GitHub 或 CNB Release 地址")
-	}
-}
-
-func validateInstallerMirrorURL(value string, tagName string, installerName string) error {
-	if err := validateUpdateURL(value); err != nil {
-		return err
+		return errors.New("安装包必须使用官方 HTTPS Release 地址")
 	}
 	canonicalTag := normalizeTagName(tagName)
 	if versionKey(canonicalTag) == nil || installerName == "" {
@@ -785,21 +634,6 @@ func preferCNBMirror(values []string) []string {
 		}
 	}
 	return result
-}
-
-func mergeMirrorURLs(groups ...[]string) []string {
-	seen := make(map[string]struct{})
-	merged := make([]string, 0, maxInstallerMirrorCount)
-	for _, group := range groups {
-		for _, value := range group {
-			if _, exists := seen[value]; exists || len(merged) >= maxInstallerMirrorCount {
-				continue
-			}
-			seen[value] = struct{}{}
-			merged = append(merged, value)
-		}
-	}
-	return preferCNBMirror(merged)
 }
 
 func updateMirrorLabel(value string) string {

--- a/desktop/internal/services/updater_test.go
+++ b/desktop/internal/services/updater_test.go
@@ -101,6 +101,10 @@ func TestUpdaterAcceptsOnlyExactOfficialInstallerURLs(t *testing.T) {
 		"https://github.com/Hypostasis-Cat/HypoMux/releases/download/v2.5.9/" + installerName,
 		"https://github.com/another/repository/releases/download/v2.5.8/" + installerName,
 		"https://cnb.cool/another/repository/-/releases/download/v2.5.8/" + installerName,
+		githubLatestManifestURL,
+		githubLatestManifestURL + ".sig",
+		cnbLatestManifestURL,
+		cnbLatestManifestURL + ".sig",
 	} {
 		if validateInstallerMirrorURL(value, tagName, installerName) == nil {
 			t.Fatalf("unsafe installer URL was accepted: %s", value)
@@ -109,6 +113,35 @@ func TestUpdaterAcceptsOnlyExactOfficialInstallerURLs(t *testing.T) {
 	for _, value := range officialInstallerMirrors(tagName, installerName) {
 		if err := validateInstallerMirrorURL(value, tagName, installerName); err != nil {
 			t.Fatalf("official installer URL rejected: %s: %v", value, err)
+		}
+	}
+}
+
+func TestUpdaterAcceptsOnlyExactSignedUpdateChannelURLs(t *testing.T) {
+	for _, value := range []string{
+		githubLatestManifestURL,
+		githubLatestManifestURL + ".sig",
+		cnbLatestManifestURL,
+		cnbLatestManifestURL + ".sig",
+	} {
+		if err := validateUpdateMetadataURL(value); err != nil {
+			t.Fatalf("official metadata URL rejected: %s: %v", value, err)
+		}
+	}
+	for _, value := range []string{
+		"http://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json",
+		"https://user@raw.githubusercontent.com/Hypostasis-Cat/HypoMux/update-channel/latest.json",
+		"https://raw.githubusercontent.com.example.invalid/Hypostasis-Cat/HypoMux/update-channel/latest.json",
+		"https://raw.githubusercontent.com:443/Hypostasis-Cat/HypoMux/update-channel/latest.json",
+		githubLatestManifestURL + "?cache=off",
+		githubLatestManifestURL + "#fragment",
+		"https://raw.githubusercontent.com/Hypostasis-Cat/HypoMux/main/latest.json",
+		"https://cnb.cool/Hypostasis-Cat/HypoMux/-/git/raw/main/latest.json",
+		"https://cnb.cool/another/repository/-/git/raw/update-channel/latest.json",
+		releaseDownloadURL + "v2.5.8/HypoMux_Setup_2.5.8.exe",
+	} {
+		if validateUpdateMetadataURL(value) == nil {
+			t.Fatalf("unsafe metadata URL was accepted: %s", value)
 		}
 	}
 }
@@ -176,6 +209,15 @@ func TestUpdaterRejectsConflictingMetadataForSameVersion(t *testing.T) {
 	}
 }
 
+func TestUpdaterRejectsNonInstallerMetadataConflictForSameVersion(t *testing.T) {
+	left := releaseFromTestManifest(t, testManifest("2.5.8", []byte("payload")))
+	right := left
+	right.Notes = "different signed release notes"
+	if _, err := selectLatestRelease([]ReleaseInfo{left, right}); err == nil {
+		t.Fatal("conflicting non-installer metadata for one version was accepted")
+	}
+}
+
 func TestUpdaterUsesCNBManifestWhenGitHubMetadataIsUnavailable(t *testing.T) {
 	manifest, signature := signedManifestJSON(t, testManifest("2.5.8", []byte("payload")))
 	service := NewUpdaterService()
@@ -197,6 +239,104 @@ func TestUpdaterUsesCNBManifestWhenGitHubMetadataIsUnavailable(t *testing.T) {
 	if result.Release.TagName != "v2.5.8" || result.Release.InstallerURLs[0] !=
 		cnbDownloadURL+"v2.5.8/HypoMux_Setup_2.5.8.exe" {
 		t.Fatalf("CNB manifest result = %#v", result.Release)
+	}
+}
+
+func TestUpdaterUsesGitHubManifestWhenCNBMetadataIsUnavailable(t *testing.T) {
+	manifest, signature := signedManifestJSON(t, testManifest("2.5.8", []byte("payload")))
+	service := NewUpdaterService()
+	service.manifestPublicKey = testManifestPublicKey()
+	service.client = clientFor(func(request *http.Request) *http.Response {
+		switch request.URL.String() {
+		case githubLatestManifestURL:
+			return stringResponse(request, http.StatusOK, manifest)
+		case githubLatestManifestURL + ".sig":
+			return bytesResponse(request, http.StatusOK, signature)
+		default:
+			return stringResponse(request, http.StatusServiceUnavailable, "")
+		}
+	})
+
+	result, err := service.Check()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Release.TagName != "v2.5.8" {
+		t.Fatalf("GitHub fallback result = %#v", result.Release)
+	}
+}
+
+func TestUpdaterFailsClosedWhenSignedChannelsConflictForSameVersion(t *testing.T) {
+	githubManifest, githubSignature := signedManifestJSON(t, testManifest("2.5.8", []byte("github")))
+	cnbManifest, cnbSignature := signedManifestJSON(t, testManifest("2.5.8", []byte("cnb")))
+	service := NewUpdaterService()
+	service.manifestPublicKey = testManifestPublicKey()
+	service.client = clientFor(func(request *http.Request) *http.Response {
+		switch request.URL.String() {
+		case githubLatestManifestURL:
+			return stringResponse(request, http.StatusOK, githubManifest)
+		case githubLatestManifestURL + ".sig":
+			return bytesResponse(request, http.StatusOK, githubSignature)
+		case cnbLatestManifestURL:
+			return stringResponse(request, http.StatusOK, cnbManifest)
+		case cnbLatestManifestURL + ".sig":
+			return bytesResponse(request, http.StatusOK, cnbSignature)
+		default:
+			return stringResponse(request, http.StatusNotFound, "")
+		}
+	})
+
+	if result, err := service.Check(); err == nil {
+		t.Fatalf("conflicting signed channels were accepted: %#v", result)
+	}
+}
+
+func TestUpdaterIgnoresTamperedChannelWhenOtherChannelIsTrusted(t *testing.T) {
+	manifest, signature := signedManifestJSON(t, testManifest("2.5.8", []byte("payload")))
+	service := NewUpdaterService()
+	service.manifestPublicKey = testManifestPublicKey()
+	service.client = clientFor(func(request *http.Request) *http.Response {
+		switch request.URL.String() {
+		case cnbLatestManifestURL:
+			return stringResponse(request, http.StatusOK, manifest+" ")
+		case cnbLatestManifestURL + ".sig":
+			return bytesResponse(request, http.StatusOK, signature)
+		case githubLatestManifestURL:
+			return stringResponse(request, http.StatusOK, manifest)
+		case githubLatestManifestURL + ".sig":
+			return bytesResponse(request, http.StatusOK, signature)
+		default:
+			return stringResponse(request, http.StatusNotFound, "")
+		}
+	})
+
+	result, err := service.Check()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Release.TagName != "v2.5.8" {
+		t.Fatalf("trusted fallback result = %#v", result.Release)
+	}
+}
+
+func TestUpdaterFailsWhenBothChannelSignaturesAreInvalid(t *testing.T) {
+	manifest, _ := signedManifestJSON(t, testManifest("2.5.8", []byte("payload")))
+	invalidSignature := make([]byte, ed25519.SignatureSize)
+	service := NewUpdaterService()
+	service.manifestPublicKey = testManifestPublicKey()
+	service.client = clientFor(func(request *http.Request) *http.Response {
+		switch request.URL.String() {
+		case cnbLatestManifestURL, githubLatestManifestURL:
+			return stringResponse(request, http.StatusOK, manifest)
+		case cnbLatestManifestURL + ".sig", githubLatestManifestURL + ".sig":
+			return bytesResponse(request, http.StatusOK, invalidSignature)
+		default:
+			return stringResponse(request, http.StatusNotFound, "")
+		}
+	})
+
+	if result, err := service.Check(); err == nil {
+		t.Fatalf("invalid signed channels were accepted: %#v", result)
 	}
 }
 
@@ -231,114 +371,6 @@ func TestUpdaterRejectsMissingTamperedOrWrongManifestSignature(t *testing.T) {
 				t.Fatal("untrusted manifest was accepted")
 			}
 		})
-	}
-}
-
-func TestGitHubTagDiscoveryUsesSignedManifestAndCNBDownloadFallback(t *testing.T) {
-	payload := []byte("signed-installer-placeholder")
-	manifest, signature := signedManifestJSON(t, testManifest("2.5.8", payload))
-	taggedManifestURL := releaseDownloadURL + "v2.5.8/" + updateManifestName
-	apiPayload := `{
-  "tag_name":"v2.5.8",
-  "name":"forged unsigned metadata",
-  "assets":[{
-    "name":"HypoMux_Setup_2.5.8.exe",
-    "browser_download_url":"https://github.com/Hypostasis-Cat/HypoMux/releases/download/v2.5.8/HypoMux_Setup_2.5.8.exe",
-    "size":999999,
-    "digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  }]
-}`
-	service := NewUpdaterService()
-	service.manifestPublicKey = testManifestPublicKey()
-	service.verifyInstaller = func(string) error { return nil }
-	service.client = clientFor(func(request *http.Request) *http.Response {
-		switch request.URL.String() {
-		case latestReleaseAPI:
-			return stringResponse(request, http.StatusOK, apiPayload)
-		case taggedManifestURL:
-			return stringResponse(request, http.StatusOK, manifest)
-		case taggedManifestURL + ".sig":
-			return bytesResponse(request, http.StatusOK, signature)
-		case releaseDownloadURL + "v2.5.8/HypoMux_Setup_2.5.8.exe":
-			return stringResponse(request, http.StatusServiceUnavailable, "")
-		case cnbDownloadURL + "v2.5.8/HypoMux_Setup_2.5.8.exe":
-			return bytesResponse(request, http.StatusOK, payload)
-		default:
-			return stringResponse(request, http.StatusNotFound, "")
-		}
-	})
-
-	result, err := service.Check()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Mirror lists are generic. Reversing the default CNB-first preference
-	// proves that download fallback is independent from the metadata source.
-	result.Release.InstallerURLs[0], result.Release.InstallerURLs[1] =
-		result.Release.InstallerURLs[1], result.Release.InstallerURLs[0]
-	installerPath, err := service.Download(result.Release)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(filepath.Dir(installerPath))
-}
-
-func TestGitHubAPICannotBypassSignedManifest(t *testing.T) {
-	const apiPayload = `{
-  "tag_name":"v99.0.0",
-  "name":"forged unsigned release",
-  "body":"must never enter ReleaseInfo",
-  "html_url":"https://github.com/Hypostasis-Cat/HypoMux/releases/tag/v99.0.0",
-  "assets":[{
-    "name":"HypoMux_Setup_99.0.0.exe",
-    "browser_download_url":"https://github.com/Hypostasis-Cat/HypoMux/releases/download/v99.0.0/HypoMux_Setup_99.0.0.exe",
-    "size":1,
-    "digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  }]
-}`
-	service := NewUpdaterService()
-	service.manifestPublicKey = testManifestPublicKey()
-	service.client = clientFor(func(request *http.Request) *http.Response {
-		if request.URL.String() == latestReleaseAPI {
-			return stringResponse(request, http.StatusOK, apiPayload)
-		}
-		return stringResponse(request, http.StatusNotFound, "")
-	})
-
-	if release, err := service.checkGitHubAPI(context.Background()); err == nil {
-		t.Fatalf("unsigned GitHub API metadata entered ReleaseInfo: %#v", release)
-	}
-}
-
-func TestUpdaterFallsBackToTaggedManifestThroughReleaseFeed(t *testing.T) {
-	const feed = `<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom"><entry>
-  <title>HypoMux 2.5.8</title>
-  <link rel="alternate" href="https://github.com/Hypostasis-Cat/HypoMux/releases/tag/v2.5.8" />
-</entry></feed>`
-	manifest, signature := signedManifestJSON(t, testManifest("2.5.8", []byte("payload")))
-	taggedManifestURL := releaseDownloadURL + "v2.5.8/" + updateManifestName
-	service := NewUpdaterService()
-	service.manifestPublicKey = testManifestPublicKey()
-	service.client = clientFor(func(request *http.Request) *http.Response {
-		switch request.URL.String() {
-		case releasesFeedURL:
-			return stringResponse(request, http.StatusOK, feed)
-		case taggedManifestURL:
-			return stringResponse(request, http.StatusOK, manifest)
-		case taggedManifestURL + ".sig":
-			return bytesResponse(request, http.StatusOK, signature)
-		default:
-			return stringResponse(request, http.StatusServiceUnavailable, "")
-		}
-	})
-
-	result, err := service.Check()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Release.TagName != "v2.5.8" || result.Release.InstallerSize != int64(len("payload")) {
-		t.Fatalf("Atom fallback result = %#v", result.Release)
 	}
 }
 


### PR DESCRIPTION
## What changed

- move signed updater metadata from Release assets to a dedicated `update-channel` branch mirrored byte-for-byte to GitHub and CNB
- require every trusted `ReleaseInfo` to originate from an Ed25519-verified manifest, with strict metadata and installer URL validation
- explicitly synchronize annotated release tags to CNB and make tag/release/channel steps safe to rerun
- upload and verify one SignPath-signed installer on both Release mirrors before advancing the update channel
- extend the read-only release trust smoke test and document the resulting trust model

## Why

This keeps public Release pages clean, removes CNB tag-mirroring races, prevents unsigned GitHub discovery data from entering the updater trust chain, and ensures clients do not see a new version until both installer mirrors are ready.

## Validation

- `gofmt`
- desktop and engine `go test ./... -count=1`
- desktop and engine `go vet ./...`
- frontend tests (13 passed)
- frontend production build
- Wails Windows build
- `actionlint`
- `git diff --check`

No existing v2.5.7 Release, tag, or online update channel was modified by this change.