### PR TITLE
feat: link adapters to sortable active connections

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -20,9 +20,11 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^6.0.0",
+    "jsdom": "^30.0.1",
     "typescript": "^5.2.2",
     "vite": "^8.0.5",
     "vitest": "^4.1.10"

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -28,11 +28,14 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-markdown:
         specifier: ^10.1.0
-        version: 10.1.0(@types/react@18.3.31)(react@18.3.1)(supports-color@7.2.0)
+        version: 10.1.0(@types/react@18.3.31)(react@18.3.1)
       remark-gfm:
         specifier: ^4.0.1
-        version: 4.0.1(supports-color@7.2.0)
+        version: 4.0.1
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.2.43
         version: 18.3.31
@@ -42,6 +45,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.0
         version: 6.0.4(vite@8.1.5)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -50,9 +56,21 @@ importers:
         version: 8.1.5
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.1.5)
+        version: 4.1.10(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.1.5)
 
 packages:
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -79,6 +97,46 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@ctrl/tinycolor@3.6.1':
     resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
     engines: {node: '>=10'}
@@ -94,6 +152,15 @@ packages:
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
@@ -760,8 +827,30 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -861,6 +950,17 @@ packages:
   '@wailsio/runtime@3.0.0-alpha2.119':
     resolution: {integrity: sha512-j8Py9HO+7gMvvYXCfGklS4cE+QUd59dYc6eH3ttpSkw28inaKUrViNe67ZDwEfzcgUZakxe/8m+l2lomzhD6gw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -870,6 +970,9 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -896,8 +999,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -907,6 +1018,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -922,6 +1036,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   embla-carousel-autoplay@8.6.0:
     resolution: {integrity: sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==}
     peerDependencies:
@@ -934,6 +1051,10 @@ packages:
 
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -979,6 +1100,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1004,6 +1129,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -1021,6 +1149,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   keyborg@2.14.1:
     resolution: {integrity: sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==}
@@ -1106,6 +1243,14 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1163,6 +1308,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1263,6 +1411,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1277,13 +1428,24 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -1307,6 +1469,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1314,6 +1480,10 @@ packages:
 
   rtl-css-js@1.16.1:
     resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1355,6 +1525,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabster@8.8.0:
     resolution: {integrity: sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==}
 
@@ -1373,6 +1546,21 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -1386,6 +1574,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -1500,21 +1692,68 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/helper-string-parser@7.29.7':
     optional: true
 
-  '@babel/helper-validator-identifier@7.29.7':
-    optional: true
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/parser@7.29.8':
     dependencies:
@@ -1531,6 +1770,34 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2':
     optional: true
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@ctrl/tinycolor@3.6.1': {}
 
@@ -1551,6 +1818,8 @@ snapshots:
     optional: true
 
   '@emotion/hash@0.9.2': {}
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:
@@ -2813,10 +3082,33 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2879,7 +3171,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.1.5)
+      vitest: 4.1.10(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.1.5)
     optional: true
 
   '@vitest/expect@4.1.10':
@@ -2925,6 +3217,14 @@ snapshots:
 
   '@wailsio/runtime@3.0.0-alpha2.119': {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.5:
@@ -2935,6 +3235,10 @@ snapshots:
     optional: true
 
   bail@2.0.2: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   ccount@2.0.1: {}
 
@@ -2952,13 +3256,25 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
-  debug@4.4.3(supports-color@7.2.0):
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -2972,6 +3288,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
   embla-carousel-autoplay@8.6.0(embla-carousel@8.6.0):
     dependencies:
       embla-carousel: 8.6.0
@@ -2981,6 +3299,8 @@ snapshots:
       embla-carousel: 8.6.0
 
   embla-carousel@8.6.0: {}
+
+  entities@8.0.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -3006,7 +3326,7 @@ snapshots:
   has-flag@4.0.0:
     optional: true
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
@@ -3015,9 +3335,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -3029,6 +3349,12 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-escaper@2.0.2:
     optional: true
@@ -3050,6 +3376,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   istanbul-lib-coverage@3.2.2:
     optional: true
 
@@ -3070,6 +3398,32 @@ snapshots:
     optional: true
 
   js-tokens@4.0.0: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   keyborg@2.14.1: {}
 
@@ -3128,6 +3482,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.5.2: {}
+
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3153,14 +3511,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -3178,67 +3536,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
+  mdast-util-gfm-footnote@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-table@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@7.2.0):
+  mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
@@ -3246,7 +3604,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -3255,13 +3613,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3298,6 +3656,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -3468,10 +3828,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@7.2.0):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -3506,6 +3866,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -3518,7 +3882,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   property-information@7.2.0: {}
+
+  punycode@2.3.1: {}
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -3526,17 +3898,19 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-markdown@10.1.0(@types/react@18.3.31)(react@18.3.1)(supports-color@7.2.0):
+  react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@18.3.31)(react@18.3.1):
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/react': 18.3.31
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
+      hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
       react: 18.3.1
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -3548,21 +3922,21 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  remark-gfm@4.0.1(supports-color@7.2.0):
+  remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@7.2.0):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -3581,6 +3955,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  require-from-string@2.0.2: {}
 
   rolldown@1.1.5:
     dependencies:
@@ -3606,6 +3982,10 @@ snapshots:
   rtl-css-js@1.16.1:
     dependencies:
       '@babel/runtime': 7.29.7
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -3644,6 +4024,8 @@ snapshots:
       has-flag: 4.0.0
     optional: true
 
+  symbol-tree@3.2.4: {}
+
   tabster@8.8.0:
     dependencies:
       keyborg: 2.14.1
@@ -3660,6 +4042,20 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -3667,6 +4063,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
+
+  undici@8.10.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -3725,7 +4123,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.1.5):
+  vitest@4.1.10(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.1.5):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5)
@@ -3749,12 +4147,41 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   zwitch@2.0.4: {}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { AppShell } from "./components/shell/AppShell";
 import type { AppPage } from "./components/shell/CompactNavigation";
 import { HomePage } from "./pages/HomePage";
 import { advanceConnectionsNavigation } from "./pages/connectionNavigation";
+import type { HomeAdapter } from "./state/useEngineState";
 import { AppearanceProvider, useAppearance } from "./theme/appearance.store";
 import { LanguageProvider } from "./i18n/i18n";
 import { desktopPlatform } from "./platform/desktop";
@@ -38,6 +39,7 @@ function HypoMuxWindow() {
   const [pageDirection, setPageDirection] = useState<"forward" | "backward">("forward");
   const [navigationRevision, setNavigationRevision] = useState(0);
   const [connectionsNavigation, setConnectionsNavigation] = useState({ adapter: "", revision: 0 });
+  const [connectionAdapters, setConnectionAdapters] = useState<HomeAdapter[]>([]);
   const [startupRevealed, setStartupRevealed] = useState(false);
   const { fluentTheme } = useAppearance();
   const pageOrder: AppPage[] = [
@@ -87,7 +89,12 @@ function HypoMuxWindow() {
         pageDirection={pageDirection}
         animatePage={navigationRevision > 0}
         persistentPage="home"
-        persistentChildren={<HomePage onNavigate={navigate} />}
+        persistentChildren={(
+          <HomePage
+            onNavigate={navigate}
+            onAdapterRuntimeChange={setConnectionAdapters}
+          />
+        )}
       >
         <Suspense fallback={<div className="page-loading"><Spinner /></div>}>
           {page === "appearance" && import.meta.env.DEV
@@ -104,6 +111,7 @@ function HypoMuxWindow() {
                 ? <ConnectionsPage
                   initialAdapter={connectionsNavigation.adapter}
                   adapterRevision={connectionsNavigation.revision}
+                  adapterRuntime={connectionAdapters}
                 />
             : page === "routing"
               ? <RoutingPage />

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { WallpaperLayer } from "./components/material/WallpaperLayer";
 import { AppShell } from "./components/shell/AppShell";
 import type { AppPage } from "./components/shell/CompactNavigation";
 import { HomePage } from "./pages/HomePage";
+import { advanceConnectionsNavigation } from "./pages/connectionNavigation";
 import { AppearanceProvider, useAppearance } from "./theme/appearance.store";
 import { LanguageProvider } from "./i18n/i18n";
 import { desktopPlatform } from "./platform/desktop";
@@ -36,6 +37,7 @@ function HypoMuxWindow() {
   });
   const [pageDirection, setPageDirection] = useState<"forward" | "backward">("forward");
   const [navigationRevision, setNavigationRevision] = useState(0);
+  const [connectionsNavigation, setConnectionsNavigation] = useState({ adapter: "", revision: 0 });
   const [startupRevealed, setStartupRevealed] = useState(false);
   const { fluentTheme } = useAppearance();
   const pageOrder: AppPage[] = [
@@ -49,7 +51,10 @@ function HypoMuxWindow() {
     "appearance",
   ];
 
-  const navigate = (nextPage: AppPage) => {
+  const navigate = (nextPage: AppPage, adapterName?: string) => {
+    if (nextPage === "connections") {
+      setConnectionsNavigation((current) => advanceConnectionsNavigation(current, adapterName));
+    }
     if (nextPage === page) return;
     const currentIndex = pageOrder.indexOf(page);
     const nextIndex = pageOrder.indexOf(nextPage);
@@ -96,7 +101,10 @@ function HypoMuxWindow() {
             : page === "health"
               ? <HealthPage />
               : page === "connections"
-                ? <ConnectionsPage />
+                ? <ConnectionsPage
+                  initialAdapter={connectionsNavigation.adapter}
+                  adapterRevision={connectionsNavigation.revision}
+                />
             : page === "routing"
               ? <RoutingPage />
               : null}

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1074,6 +1074,10 @@ svg {
   opacity: 0.72;
 }
 
+.network-adapter.is-navigable {
+  cursor: pointer;
+}
+
 .adapter-primary {
   display: grid;
   min-width: 0;
@@ -1097,6 +1101,24 @@ svg {
   min-width: 0;
   flex-direction: column;
   gap: 3px;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+}
+
+.adapter-name:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--hm-accent);
+  outline-offset: 3px;
+}
+
+.adapter-selection-control,
+.adapter-weight {
+  cursor: default;
 }
 
 .adapter-name strong {
@@ -2889,6 +2911,48 @@ svg {
   letter-spacing: 0.035em;
 }
 
+.connection-sort-button {
+  display: inline-flex;
+  min-width: 0;
+  padding: 5px 3px;
+  align-items: center;
+  gap: 4px;
+  border: 0;
+  border-radius: 5px;
+  color: inherit;
+  font: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.connection-table-head > span:last-child .connection-sort-button {
+  margin-left: auto;
+}
+
+.connection-sort-button:hover,
+.connection-sort-button.is-active {
+  color: var(--hm-text-primary);
+  background: color-mix(in srgb, var(--hm-accent-soft) 64%, transparent);
+}
+
+.connection-sort-button:focus-visible {
+  outline: 2px solid var(--hm-accent);
+  outline-offset: 1px;
+}
+
+.connection-sort-indicator {
+  color: var(--hm-accent-strong);
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0.58;
+}
+
+.connection-sort-button.is-active .connection-sort-indicator {
+  opacity: 1;
+}
+
 .connection-list {
   width: 100%;
   min-height: 0;
@@ -2897,6 +2961,62 @@ svg {
   overflow-anchor: none;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
+}
+
+.connection-adapter-group + .connection-adapter-group {
+  border-top: 1px solid var(--hm-outer-border);
+}
+
+.connection-adapter-heading {
+  display: flex;
+  min-height: 38px;
+  padding: 7px 15px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: color-mix(in srgb, var(--hm-accent-soft) 38%, rgba(var(--hm-surface-rgb), 0.52));
+}
+
+.connection-adapter-heading > span,
+.connection-adapter-speed,
+.connection-adapter-speed > span {
+  display: flex;
+  align-items: center;
+}
+
+.connection-adapter-heading > span {
+  min-width: 0;
+  gap: 7px;
+}
+
+.connection-adapter-heading svg {
+  color: var(--hm-accent-strong);
+}
+
+.connection-adapter-heading strong {
+  overflow: hidden;
+  color: var(--hm-text-primary);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-adapter-heading small {
+  color: var(--hm-text-tertiary);
+  font-size: 9.5px;
+  white-space: nowrap;
+}
+
+.connection-adapter-speed {
+  flex: 0 0 auto;
+  gap: 13px;
+  color: var(--hm-text-secondary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.connection-adapter-speed > span {
+  gap: 4px;
 }
 
 .connection-row {

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1116,6 +1116,10 @@ svg {
   outline-offset: 3px;
 }
 
+.adapter-name:disabled {
+  cursor: default;
+}
+
 .adapter-selection-control,
 .adapter-weight {
   cursor: default;
@@ -2841,7 +2845,8 @@ svg {
 }
 
 .connection-view-controls,
-.connection-view-controls label {
+.connection-view-controls label,
+.connection-adapter-filter {
   display: flex;
   min-width: 0;
   align-items: center;
@@ -2856,6 +2861,24 @@ svg {
   color: var(--hm-text-tertiary);
   font-size: 10.5px;
   white-space: nowrap;
+}
+
+.connection-adapter-filter {
+  gap: 5px;
+  color: var(--hm-text-tertiary);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+.connection-adapter-filter .fui-Badge {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-adapter-filter .fui-Button {
+  min-width: 0;
 }
 
 .connection-view-controls label > svg {

--- a/desktop/frontend/src/components/home/NetworkAdapterItem.tsx
+++ b/desktop/frontend/src/components/home/NetworkAdapterItem.tsx
@@ -37,6 +37,7 @@ export function NetworkAdapterItem({
   const { locale, t } = useI18n();
   const text = (zh: string, en: string) => locale === "en" ? en : zh;
   const [inputValue, setInputValue] = useState(String(adapter.weight));
+  const canOpenConnections = adapter.selected;
   useEffect(() => setInputValue(String(adapter.weight)), [adapter.weight]);
   const commit = (next: number) => {
     const normalized = Math.max(1, Math.min(100, Math.round(next)));
@@ -45,8 +46,8 @@ export function NetworkAdapterItem({
   };
   return (
     <article
-      className={`network-adapter hm-card is-navigable${adapter.selected ? " is-selected" : " is-muted"}`}
-      onClick={onOpenConnections}
+      className={`network-adapter hm-card${adapter.selected ? " is-selected is-navigable" : " is-muted"}`}
+      onClick={canOpenConnections ? onOpenConnections : undefined}
     >
       <div className="adapter-primary">
         <span className="adapter-selection-control" onClick={(event) => event.stopPropagation()}>
@@ -64,6 +65,7 @@ export function NetworkAdapterItem({
           type="button"
           className="adapter-name"
           aria-label={text(`查看 ${adapter.name} 的活动连接`, `View active connections for ${adapter.name}`)}
+          disabled={!canOpenConnections}
           onClick={(event) => {
             event.stopPropagation();
             onOpenConnections();

--- a/desktop/frontend/src/components/home/NetworkAdapterItem.tsx
+++ b/desktop/frontend/src/components/home/NetworkAdapterItem.tsx
@@ -23,12 +23,14 @@ export function NetworkAdapterItem({
   adapter,
   percentage,
   disabled,
+  onOpenConnections,
   onSelectedChange,
   onWeightChange,
 }: {
   adapter: HomeAdapter;
   percentage: number;
   disabled: boolean;
+  onOpenConnections: () => void;
   onSelectedChange: (checked: boolean) => void;
   onWeightChange: (value: number) => void;
 }) {
@@ -42,21 +44,34 @@ export function NetworkAdapterItem({
     onWeightChange(normalized);
   };
   return (
-    <article className={`network-adapter hm-card${adapter.selected ? " is-selected" : " is-muted"}`}>
+    <article
+      className={`network-adapter hm-card is-navigable${adapter.selected ? " is-selected" : " is-muted"}`}
+      onClick={onOpenConnections}
+    >
       <div className="adapter-primary">
-        <Checkbox
-          checked={adapter.selected}
-          disabled={disabled}
-          onChange={(_, data) => onSelectedChange(data.checked === true)}
-          aria-label={`${adapter.selected ? text("停用", "Disable") : text("启用", "Enable")} ${adapter.name}`}
-        />
+        <span className="adapter-selection-control" onClick={(event) => event.stopPropagation()}>
+          <Checkbox
+            checked={adapter.selected}
+            disabled={disabled}
+            onChange={(_, data) => onSelectedChange(data.checked === true)}
+            aria-label={`${adapter.selected ? text("停用", "Disable") : text("启用", "Enable")} ${adapter.name}`}
+          />
+        </span>
         <span className="adapter-icon" aria-hidden="true">
           {adapter.kind === "wifi" ? <Wifi124Regular /> : <Router24Regular />}
         </span>
-        <div className="adapter-name">
+        <button
+          type="button"
+          className="adapter-name"
+          aria-label={text(`查看 ${adapter.name} 的活动连接`, `View active connections for ${adapter.name}`)}
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenConnections();
+          }}
+        >
           <strong>{adapter.name}</strong>
           <span>{adapter.address}</span>
-        </div>
+        </button>
       </div>
 
       <div className="adapter-live" aria-label={text("实时网络状态", "Live network status")}>
@@ -71,7 +86,7 @@ export function NetworkAdapterItem({
         <span>{text("丢包", "Loss")} {adapter.lossRate === undefined ? "—" : `${adapter.lossRate}%`}</span>
       </div>
 
-      <div className="adapter-weight">
+      <div className="adapter-weight" onClick={(event) => event.stopPropagation()}>
         <div>
           <span>{t("home_bw_column")}</span>
           <strong>{percentage}% {text("份额", "share")}</strong>

--- a/desktop/frontend/src/pages/ConnectionsPage.test.tsx
+++ b/desktop/frontend/src/pages/ConnectionsPage.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConnectionListSnapshot, ConnectionView } from "../platform/services";
+import type { HomeAdapter } from "../state/useEngineState";
+import { ConnectionsPage } from "./ConnectionsPage";
+
+const mocks = vi.hoisted(() => ({
+  connections: vi.fn(),
+}));
+
+vi.mock("../platform/services", () => ({
+  appServices: { engine: { connections: mocks.connections } },
+  withServiceTimeout: <T,>(request: Promise<T>) => request,
+}));
+
+vi.mock("../i18n/i18n", () => ({
+  useI18n: () => ({ locale: "en" }),
+}));
+
+const connection = (overrides: Partial<ConnectionView>): ConnectionView => ({
+  id: 1,
+  process: "Zulu.exe",
+  protocol: "tcp",
+  client: "127.0.0.1:51001",
+  target: "ethernet.example:443",
+  domain: "ethernet.example",
+  remote_ip: "203.0.113.10",
+  remote_port: "443",
+  adapter: "Ethernet",
+  outbound: "aggregation",
+  outbound_detail: "Ethernet",
+  started_at: "2026-08-24T01:00:00Z",
+  bytes_up: 100,
+  bytes_down: 300,
+  ...overrides,
+});
+
+const connections: ConnectionView[] = [
+  connection({}),
+  connection({
+    id: 2,
+    process: "Alpha.exe",
+    target: "wifi.example:443",
+    domain: "wifi.example",
+    remote_ip: "203.0.113.20",
+    adapter: "Wi-Fi",
+    outbound_detail: "Wi-Fi",
+    started_at: "2026-08-24T01:02:00Z",
+    bytes_up: 50,
+    bytes_down: 150,
+  }),
+];
+
+const snapshot: ConnectionListSnapshot = {
+  phase: "running",
+  sampled_at: "2026-08-24T01:03:00Z",
+  connections,
+};
+
+const runtimeAdapter = (
+  name: string,
+  ifIndex: number,
+  downloadBPS: number,
+  uploadBPS: number,
+): HomeAdapter => ({
+  id: name,
+  name,
+  description: `${name} test adapter`,
+  address: `192.0.2.${ifIndex}`,
+  prefix_length: 24,
+  if_index: ifIndex,
+  dns_servers: ["192.0.2.1"],
+  metric: 25,
+  automatic_metric: true,
+  selected: true,
+  weight: 1,
+  kind: name === "Wi-Fi" ? "wifi" : "ethernet",
+  operational: true,
+  downloadBPS,
+  uploadBPS,
+  connections: 1,
+  bytesDown: 0,
+  bytesUp: 0,
+  health: "healthy",
+});
+
+const adapterRuntime = [
+  runtimeAdapter("Ethernet", 7, 400, 100),
+  runtimeAdapter("Wi-Fi", 8, 200, 50),
+];
+
+describe("ConnectionsPage interactions", () => {
+  beforeEach(() => {
+    mocks.connections.mockResolvedValue(snapshot);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows only the selected adapter with its shared live throughput", async () => {
+    render(<ConnectionsPage initialAdapter="Ethernet" adapterRuntime={adapterRuntime} />);
+
+    expect(await screen.findByText("ethernet.example")).not.toBeNull();
+    expect(screen.queryByText("wifi.example")).toBeNull();
+    expect(screen.getByText("1 connection(s)")).not.toBeNull();
+    expect(screen.getByText("400 B/s")).not.toBeNull();
+    expect(screen.getByText("100 B/s")).not.toBeNull();
+  });
+
+  it("shows and clears the adapter filter without clearing search", async () => {
+    render(<ConnectionsPage initialAdapter="Ethernet" adapterRuntime={adapterRuntime} />);
+    await screen.findByText("ethernet.example");
+
+    const adapterFilter = screen.getByRole("group", { name: "Adapter filter" });
+    expect(within(adapterFilter).getByText("Ethernet").getAttribute("title")).toBe("Ethernet");
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "wifi" } });
+    expect(screen.queryByText("wifi.example")).toBeNull();
+
+    fireEvent.click(within(adapterFilter).getByRole("button", { name: "Clear adapter filter Ethernet" }));
+
+    expect(await screen.findByText("wifi.example")).not.toBeNull();
+    expect((screen.getByRole("searchbox") as HTMLInputElement).value).toBe("wifi");
+    expect(screen.queryByRole("group", { name: "Adapter filter" })).toBeNull();
+    expect(screen.queryByText("1 connection(s)")).toBeNull();
+  });
+
+  it("preserves the egress policy when the adapter filter is cleared", async () => {
+    render(<ConnectionsPage initialAdapter="Ethernet" adapterRuntime={adapterRuntime} />);
+    await screen.findByText("ethernet.example");
+
+    const egressFilter = screen.getByRole("combobox", { name: "Filter by egress policy" }) as HTMLButtonElement;
+    fireEvent.click(egressFilter);
+    fireEvent.click(await screen.findByRole("option", { name: "Aggregated" }));
+    expect(egressFilter.value).toBe("Aggregated");
+
+    const adapterFilter = screen.getByRole("group", { name: "Adapter filter" });
+    fireEvent.click(within(adapterFilter).getByRole("button", { name: "Clear adapter filter Ethernet" }));
+
+    expect(egressFilter.value).toBe("Aggregated");
+    expect(await screen.findByText("wifi.example")).not.toBeNull();
+  });
+
+  it("clears the search query when adapter navigation advances", async () => {
+    const view = render(
+      <ConnectionsPage initialAdapter="" adapterRevision={1} adapterRuntime={adapterRuntime} />,
+    );
+    await screen.findByText("ethernet.example");
+
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "wifi" } });
+    expect(screen.queryByText("ethernet.example")).toBeNull();
+    expect(screen.getByText("wifi.example")).not.toBeNull();
+
+    view.rerender(
+      <ConnectionsPage initialAdapter="" adapterRevision={2} adapterRuntime={adapterRuntime} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ethernet.example")).not.toBeNull();
+      expect(screen.getByText("wifi.example")).not.toBeNull();
+    });
+  });
+
+  it("reorders visible rows when a sortable column is clicked", async () => {
+    render(<ConnectionsPage adapterRuntime={adapterRuntime} />);
+    await screen.findByText("ethernet.example");
+
+    fireEvent.click(screen.getByRole("button", { name: "Sort Process ascending" }));
+
+    const rows = screen.getAllByRole("article");
+    expect(within(rows[0]).getByText("Alpha.exe")).not.toBeNull();
+    expect(within(rows[1]).getByText("Zulu.exe")).not.toBeNull();
+  });
+});

--- a/desktop/frontend/src/pages/ConnectionsPage.tsx
+++ b/desktop/frontend/src/pages/ConnectionsPage.tsx
@@ -15,7 +15,6 @@ import {
 import {
   AppsListDetail24Regular,
   ArrowDownload20Regular,
-  ArrowSort20Regular,
   ArrowSync20Regular,
   ArrowUpload20Regular,
   Filter20Regular,
@@ -30,14 +29,19 @@ import {
   appServices,
   type ConnectionListSnapshot,
   type ConnectionView,
+  type EngineSnapshot,
   withServiceTimeout,
 } from "../platform/services";
 import { startSerialPoll } from "../platform/serialPoll";
+import { groupConnectionsByAdapter } from "./connectionGroups";
 import {
   selectConnections,
-  type ConnectionDurationSort,
   type ConnectionOutboundFilter,
 } from "./connectionView";
+import {
+  type ConnectionSort,
+  type ConnectionSortKey,
+} from "./connectionSort";
 
 const emptySnapshot: ConnectionListSnapshot = {
   phase: "stopped",
@@ -64,7 +68,13 @@ const formatDuration = (startedAt: string, now: number) => {
     : `${minutes}:${String(remaining).padStart(2, "0")}`;
 };
 
-export function ConnectionsPage() {
+export function ConnectionsPage({
+  initialAdapter = "",
+  adapterRevision = 0,
+}: {
+  initialAdapter?: string;
+  adapterRevision?: number;
+}) {
   const { locale } = useI18n();
   const text = useCallback((zh: string, en: string) => locale === "en" ? en : zh, [locale]);
   const [snapshot, setSnapshot] = useState<ConnectionListSnapshot>(emptySnapshot);
@@ -73,19 +83,35 @@ export function ConnectionsPage() {
   const [live, setLive] = useState(true);
   const [query, setQuery] = useState("");
   const [outboundFilter, setOutboundFilter] = useState<ConnectionOutboundFilter>("all");
-  const [durationSort, setDurationSort] = useState<ConnectionDurationSort>("longest");
+  const [sort, setSort] = useState<ConnectionSort>({ key: "duration", direction: "descending" });
+  const [adapterRuntime, setAdapterRuntime] = useState<NonNullable<EngineSnapshot["adapters"]>>([]);
   const [now, setNow] = useState(Date.now());
   const requestActive = useRef(false);
   const connectionListRef = useRef<HTMLDivElement>(null);
   const pendingScrollTop = useRef<number | null>(null);
   const toasterId = useId("connections-toaster");
   const { dispatchToast } = useToastController(toasterId);
+  const adapterFilter = initialAdapter.trim();
+  const groupedByAdapter = adapterFilter.length > 0;
+
+  useEffect(() => {
+    setQuery("");
+    setOutboundFilter("all");
+    if (!initialAdapter.trim()) setAdapterRuntime([]);
+  }, [adapterRevision, initialAdapter]);
 
   const load = useCallback(async (manual = false) => {
     if (requestActive.current) return;
     requestActive.current = true;
     if (manual) setRefreshing(true);
     try {
+      const runtimeRequest = groupedByAdapter
+        ? withServiceTimeout(
+          appServices.engine.snapshot(),
+          2_000,
+          text("读取网卡实时速度", "Loading adapter throughput"),
+        ).catch(() => null)
+        : Promise.resolve(null);
       const next = await withServiceTimeout(
         appServices.engine.connections(),
         8_000,
@@ -93,6 +119,9 @@ export function ConnectionsPage() {
       );
       pendingScrollTop.current = connectionListRef.current?.scrollTop ?? null;
       setSnapshot({ ...next, connections: next.connections ?? [] });
+      void runtimeRequest.then((runtime) => {
+        if (runtime) setAdapterRuntime(runtime.adapters ?? []);
+      });
     } catch (error) {
       dispatchToast(
         <Toast>
@@ -106,7 +135,7 @@ export function ConnectionsPage() {
       setLoading(false);
       setRefreshing(false);
     }
-  }, [dispatchToast, text]);
+  }, [dispatchToast, groupedByAdapter, text]);
 
   useEffect(() => {
     void load();
@@ -130,9 +159,10 @@ export function ConnectionsPage() {
     pendingScrollTop.current = null;
   }, [snapshot]);
 
-  const filtered = useMemo(() => {
-    return selectConnections(snapshot.connections, query, outboundFilter, durationSort);
-  }, [durationSort, outboundFilter, query, snapshot.connections]);
+  const filtered = useMemo(
+    () => selectConnections(snapshot.connections, query, outboundFilter, adapterFilter, sort),
+    [adapterFilter, outboundFilter, query, snapshot.connections, sort],
+  );
 
   const totals = useMemo(() => snapshot.connections.reduce(
     (current, connection) => ({
@@ -141,6 +171,11 @@ export function ConnectionsPage() {
     }),
     { up: 0, down: 0 },
   ), [snapshot.connections]);
+
+  const groups = useMemo(
+    () => groupedByAdapter ? groupConnectionsByAdapter(filtered, adapterRuntime) : [],
+    [adapterRuntime, filtered, groupedByAdapter],
+  );
 
   const policy = (connection: ConnectionView) => {
     if (connection.outbound === "direct") {
@@ -156,6 +191,55 @@ export function ConnectionsPage() {
   };
 
   const engineRunning = snapshot.phase === "running";
+  const hasViewFilter = query.trim().length > 0 || outboundFilter !== "all" || groupedByAdapter;
+  const columns: Array<{ key: ConnectionSortKey; label: string }> = [
+    { key: "process", label: text("进程", "Process") },
+    { key: "destination", label: text("目标", "Destination") },
+    { key: "policy", label: text("出口策略", "Egress policy") },
+    { key: "traffic", label: text("流量", "Traffic") },
+    { key: "duration", label: text("时长", "Duration") },
+  ];
+
+  const renderConnection = (connection: ConnectionView) => {
+    const outbound = policy(connection);
+    const identity = connection.process || connection.domain || connection.remote_ip || connection.target;
+    const identitySource = connection.process
+      ? `${connection.protocol.toUpperCase()} · ${connection.client || "—"}`
+      : connection.domain
+        ? text("按目标域名显示", "Shown by destination domain")
+        : connection.remote_ip || connection.target
+          ? text("按远端 IP 显示", "Shown by remote IP")
+          : text("未识别连接", "Unidentified connection");
+    return (
+      <article className="connection-row" key={connection.id}>
+        <div className="connection-process">
+          <span className="connection-process-icon"><AppsListDetail24Regular /></span>
+          <span>
+            <strong>{identity || text("未识别连接", "Unidentified connection")}</strong>
+            <small>{identitySource}</small>
+          </span>
+        </div>
+        <div className="connection-destination">
+          <strong>{connection.domain || connection.remote_ip || connection.target || "—"}</strong>
+          <small>{connection.remote_ip && connection.domain ? `${connection.remote_ip}:${connection.remote_port || ""}` : connection.target || "—"}</small>
+        </div>
+        <div className="connection-policy">
+          <Badge appearance="tint" color={outbound.color}>{outbound.label}</Badge>
+          <small>{connection.adapter
+            ? text(`实际出口：${connection.adapter}`, `Actual egress: ${connection.adapter}`)
+            : text("出口待建立", "Egress pending")}</small>
+        </div>
+        <div className="connection-traffic">
+          <span><ArrowUpload20Regular /> {formatBytes(connection.bytes_up)}</span>
+          <span><ArrowDownload20Regular /> {formatBytes(connection.bytes_down)}</span>
+        </div>
+        <div className="connection-duration">
+          <strong>{formatDuration(connection.started_at, now)}</strong>
+          <small>{new Date(connection.started_at).toLocaleTimeString(locale === "en" ? "en-US" : "zh-CN", { hour12: false })}</small>
+        </div>
+      </article>
+    );
+  };
 
   return (
     <main className="connections-page">
@@ -233,29 +317,31 @@ export function ConnectionsPage() {
                 <Option value="adapter">{text("指定网卡", "Specified NIC")}</Option>
               </Dropdown>
             </label>
-            <label>
-              <ArrowSort20Regular />
-              <span>{text("时长", "Duration")}</span>
-              <Dropdown
-                appearance="filled-darker"
-                size="small"
-                aria-label={text("按连接时长排序", "Sort by connection duration")}
-                value={durationSort === "longest" ? text("最长优先", "Longest first") : text("最短优先", "Shortest first")}
-                selectedOptions={[durationSort]}
-                onOptionSelect={(_, data) => data.optionValue && setDurationSort(data.optionValue as ConnectionDurationSort)}
-              >
-                <Option value="longest">{text("最长优先", "Longest first")}</Option>
-                <Option value="shortest">{text("最短优先", "Shortest first")}</Option>
-              </Dropdown>
-            </label>
           </div>
         </div>
         <div className="connection-table-head" role="row">
-          <span>{text("进程", "Process")}</span>
-          <span>{text("目标", "Destination")}</span>
-          <span>{text("出口策略", "Egress policy")}</span>
-          <span>{text("流量", "Traffic")}</span>
-          <span>{text("时长", "Duration")}</span>
+          {columns.map((column) => {
+            const direction = sort.key === column.key ? sort.direction : undefined;
+            const nextDirection = direction === "ascending" ? "descending" : "ascending";
+            return (
+              <span key={column.key} role="columnheader" aria-sort={direction ?? "none"}>
+                <button
+                  type="button"
+                  className={`connection-sort-button${direction ? " is-active" : ""}`}
+                  aria-label={text(
+                    `按${column.label}${nextDirection === "ascending" ? "升序" : "降序"}排序`,
+                    `Sort ${column.label} ${nextDirection}`,
+                  )}
+                  onClick={() => setSort({ key: column.key, direction: nextDirection })}
+                >
+                  <span>{column.label}</span>
+                  <span className="connection-sort-indicator" aria-hidden="true">
+                    {direction === "ascending" ? "↑" : direction === "descending" ? "↓" : "↕"}
+                  </span>
+                </button>
+              </span>
+            );
+          })}
         </div>
         <div ref={connectionListRef} className="connection-list">
           {loading ? (
@@ -267,47 +353,29 @@ export function ConnectionsPage() {
               <span>{text("启动聚合后，这里会实时显示本次会话正在处理的连接。", "Start aggregation to see the connections handled in this session.")}</span>
             </div>
           ) : filtered.length === 0 ? (
-            <div key={query || outboundFilter !== "all" ? "connections-no-match" : "connections-idle"} className="connections-empty motion-state-content">
+            <div key={hasViewFilter ? "connections-no-match" : "connections-idle"} className="connections-empty motion-state-content">
               <Globe20Regular />
-              <strong>{query || outboundFilter !== "all" ? text("没有符合当前筛选的连接", "No connections match the current filters") : text("当前没有活动连接", "No active connections")}</strong>
-              <span>{query || outboundFilter !== "all"
+              <strong>{hasViewFilter ? text("没有符合当前筛选的连接", "No connections match the current filters") : text("当前没有活动连接", "No active connections")}</strong>
+              <span>{hasViewFilter
                 ? text("可以更换出口策略或清空搜索内容。", "Choose another egress policy or clear the search query.")
                 : text("短连接可能只会短暂出现；实时刷新会保留最新状态。", "Short-lived flows may appear briefly; live refresh keeps the view current.")}</span>
             </div>
-          ) : filtered.map((connection) => {
-            const outbound = policy(connection);
-            const identity = connection.process || text("未识别进程", "Unknown process");
-            const identitySource = `${connection.protocol.toUpperCase()} · ${connection.client || "—"}`;
-            return (
-              <article className="connection-row" key={connection.id}>
-                <div className="connection-process">
-                  <span className="connection-process-icon"><AppsListDetail24Regular /></span>
-                  <span>
-                    <strong>{identity}</strong>
-                    <small>{identitySource}</small>
-                  </span>
-                </div>
-                <div className="connection-destination">
-                  <strong>{connection.domain || connection.remote_ip || connection.target || "—"}</strong>
-                  <small>{connection.remote_ip && connection.domain ? `${connection.remote_ip}:${connection.remote_port || ""}` : connection.target || "—"}</small>
-                </div>
-                <div className="connection-policy">
-                  <Badge appearance="tint" color={outbound.color}>{outbound.label}</Badge>
-                  <small>{connection.adapter
-                    ? text(`实际出口：${connection.adapter}`, `Actual egress: ${connection.adapter}`)
-                    : text("出口待建立", "Egress pending")}</small>
-                </div>
-                <div className="connection-traffic">
-                  <span><ArrowUpload20Regular /> {formatBytes(connection.bytes_up)}</span>
-                  <span><ArrowDownload20Regular /> {formatBytes(connection.bytes_down)}</span>
-                </div>
-                <div className="connection-duration">
-                  <strong>{formatDuration(connection.started_at, now)}</strong>
-                  <small>{new Date(connection.started_at).toLocaleTimeString(locale === "en" ? "en-US" : "zh-CN", { hour12: false })}</small>
-                </div>
-              </article>
-            );
-          })}
+          ) : groupedByAdapter ? groups.map((group) => (
+            <section className="connection-adapter-group" key={group.adapter || "pending-adapter"}>
+              <div className="connection-adapter-heading">
+                <span>
+                  <PlugConnected20Regular />
+                  <strong>{group.adapter || text("出口待分配", "Egress pending")}</strong>
+                  <small>{text(`${group.connections.length} 条连接`, `${group.connections.length} connection(s)`)}</small>
+                </span>
+                <span className="connection-adapter-speed">
+                  <span><ArrowDownload20Regular /> {formatBytes(Math.round(group.downloadBPS))}/s</span>
+                  <span><ArrowUpload20Regular /> {formatBytes(Math.round(group.uploadBPS))}/s</span>
+                </span>
+              </div>
+              {group.connections.map(renderConnection)}
+            </section>
+          )) : filtered.map(renderConnection)}
         </div>
       </GlassSurface>
     </main>

--- a/desktop/frontend/src/pages/ConnectionsPage.tsx
+++ b/desktop/frontend/src/pages/ConnectionsPage.tsx
@@ -29,10 +29,10 @@ import {
   appServices,
   type ConnectionListSnapshot,
   type ConnectionView,
-  type EngineSnapshot,
   withServiceTimeout,
 } from "../platform/services";
 import { startSerialPoll } from "../platform/serialPoll";
+import type { HomeAdapter } from "../state/useEngineState";
 import { groupConnectionsByAdapter } from "./connectionGroups";
 import {
   selectConnections,
@@ -71,9 +71,11 @@ const formatDuration = (startedAt: string, now: number) => {
 export function ConnectionsPage({
   initialAdapter = "",
   adapterRevision = 0,
+  adapterRuntime = [],
 }: {
   initialAdapter?: string;
   adapterRevision?: number;
+  adapterRuntime?: readonly HomeAdapter[];
 }) {
   const { locale } = useI18n();
   const text = useCallback((zh: string, en: string) => locale === "en" ? en : zh, [locale]);
@@ -84,7 +86,6 @@ export function ConnectionsPage({
   const [query, setQuery] = useState("");
   const [outboundFilter, setOutboundFilter] = useState<ConnectionOutboundFilter>("all");
   const [sort, setSort] = useState<ConnectionSort>({ key: "duration", direction: "descending" });
-  const [adapterRuntime, setAdapterRuntime] = useState<NonNullable<EngineSnapshot["adapters"]>>([]);
   const [now, setNow] = useState(Date.now());
   const requestActive = useRef(false);
   const connectionListRef = useRef<HTMLDivElement>(null);
@@ -97,7 +98,6 @@ export function ConnectionsPage({
   useEffect(() => {
     setQuery("");
     setOutboundFilter("all");
-    if (!initialAdapter.trim()) setAdapterRuntime([]);
   }, [adapterRevision, initialAdapter]);
 
   const load = useCallback(async (manual = false) => {
@@ -105,13 +105,6 @@ export function ConnectionsPage({
     requestActive.current = true;
     if (manual) setRefreshing(true);
     try {
-      const runtimeRequest = groupedByAdapter
-        ? withServiceTimeout(
-          appServices.engine.snapshot(),
-          2_000,
-          text("读取网卡实时速度", "Loading adapter throughput"),
-        ).catch(() => null)
-        : Promise.resolve(null);
       const next = await withServiceTimeout(
         appServices.engine.connections(),
         8_000,
@@ -119,9 +112,6 @@ export function ConnectionsPage({
       );
       pendingScrollTop.current = connectionListRef.current?.scrollTop ?? null;
       setSnapshot({ ...next, connections: next.connections ?? [] });
-      void runtimeRequest.then((runtime) => {
-        if (runtime) setAdapterRuntime(runtime.adapters ?? []);
-      });
     } catch (error) {
       dispatchToast(
         <Toast>
@@ -135,7 +125,7 @@ export function ConnectionsPage({
       setLoading(false);
       setRefreshing(false);
     }
-  }, [dispatchToast, groupedByAdapter, text]);
+  }, [dispatchToast, text]);
 
   useEffect(() => {
     void load();

--- a/desktop/frontend/src/pages/ConnectionsPage.tsx
+++ b/desktop/frontend/src/pages/ConnectionsPage.tsx
@@ -17,6 +17,7 @@ import {
   ArrowDownload20Regular,
   ArrowSync20Regular,
   ArrowUpload20Regular,
+  Dismiss16Regular,
   Filter20Regular,
   Globe20Regular,
   PlugConnected20Regular,
@@ -85,6 +86,7 @@ export function ConnectionsPage({
   const [live, setLive] = useState(true);
   const [query, setQuery] = useState("");
   const [outboundFilter, setOutboundFilter] = useState<ConnectionOutboundFilter>("all");
+  const [adapterFilter, setAdapterFilter] = useState(initialAdapter.trim());
   const [sort, setSort] = useState<ConnectionSort>({ key: "duration", direction: "descending" });
   const [now, setNow] = useState(Date.now());
   const requestActive = useRef(false);
@@ -92,10 +94,10 @@ export function ConnectionsPage({
   const pendingScrollTop = useRef<number | null>(null);
   const toasterId = useId("connections-toaster");
   const { dispatchToast } = useToastController(toasterId);
-  const adapterFilter = initialAdapter.trim();
   const groupedByAdapter = adapterFilter.length > 0;
 
   useEffect(() => {
+    setAdapterFilter(initialAdapter.trim());
     setQuery("");
     setOutboundFilter("all");
   }, [adapterRevision, initialAdapter]);
@@ -286,6 +288,25 @@ export function ConnectionsPage({
             {text(`显示 ${filtered.length} / ${snapshot.connections.length}`, `Showing ${filtered.length} of ${snapshot.connections.length}`)}
           </span>
           <div className="connection-view-controls">
+            {groupedByAdapter && (
+              <div
+                className="connection-adapter-filter"
+                role="group"
+                aria-label={text("适配器筛选", "Adapter filter")}
+              >
+                <span>{text("适配器", "Adapter")}</span>
+                <Badge appearance="tint" color="brand" title={adapterFilter}>{adapterFilter}</Badge>
+                <Button
+                  appearance="subtle"
+                  size="small"
+                  icon={<Dismiss16Regular />}
+                  aria-label={text(`清除适配器筛选 ${adapterFilter}`, `Clear adapter filter ${adapterFilter}`)}
+                  onClick={() => setAdapterFilter("")}
+                >
+                  {text("清除", "Clear")}
+                </Button>
+              </div>
+            )}
             <label>
               <span>{text("出口策略", "Egress")}</span>
               <Dropdown

--- a/desktop/frontend/src/pages/HomePage.test.tsx
+++ b/desktop/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HomeAdapter } from "../state/useEngineState";
+import { HomePage } from "./HomePage";
+
+const mocks = vi.hoisted(() => ({
+  useEngineState: vi.fn(),
+}));
+
+vi.mock("../state/useEngineState", () => ({
+  useEngineState: mocks.useEngineState,
+}));
+
+vi.mock("../i18n/i18n", () => ({
+  useI18n: () => ({
+    locale: "en",
+    t: (key: string) => ({
+      home_bw_column: "Weight",
+      home_bw_column_hint: "Adjust adapter weight",
+      home_refresh_tip: "Refresh",
+      home_select_all: "Select all",
+      home_deselect_all: "Deselect all",
+    })[key] ?? key,
+  }),
+}));
+
+const adapter: HomeAdapter = {
+  id: "Ethernet",
+  name: "Ethernet",
+  description: "Realtek PCIe",
+  address: "192.0.2.10",
+  prefix_length: 24,
+  if_index: 7,
+  dns_servers: ["192.0.2.1"],
+  metric: 25,
+  automatic_metric: true,
+  selected: true,
+  weight: 3,
+  kind: "ethernet",
+  operational: true,
+  downloadBPS: 1024,
+  uploadBPS: 512,
+  connections: 2,
+  bytesDown: 4096,
+  bytesUp: 2048,
+  health: "healthy",
+};
+
+const engineState = () => ({
+  phase: "stopped",
+  mode: "proxy",
+  weighted: false,
+  adapters: [adapter],
+  selected: [adapter],
+  totalWeight: adapter.weight,
+  history: Array.from({ length: 18 }, () => 0),
+  loading: false,
+  refreshing: false,
+  preview: false,
+  transitioning: false,
+  coreConnected: true,
+  coreVersion: "test",
+  coreElevated: false,
+  ports: { socks: 10800, http: 10801 },
+  totalDownload: adapter.downloadBPS,
+  totalUpload: adapter.uploadBPS,
+  totalConnections: adapter.connections,
+  sessionBytes: adapter.bytesDown + adapter.bytesUp,
+  setMode: vi.fn(),
+  setWeighted: vi.fn(),
+  toggleEngine: vi.fn(),
+  toggleAdapter: vi.fn(),
+  updateWeight: vi.fn(),
+  selectAll: vi.fn(),
+  refreshAdapters: vi.fn(),
+});
+
+describe("HomePage adapter interactions", () => {
+  beforeEach(() => {
+    mocks.useEngineState.mockReturnValue(engineState());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("opens active connections for the clicked adapter", () => {
+    const onNavigate = vi.fn();
+    render(<HomePage onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View active connections for Ethernet" }));
+
+    expect(onNavigate).toHaveBeenCalledOnce();
+    expect(onNavigate).toHaveBeenCalledWith("connections", "Ethernet");
+  });
+
+  it("does not open connections for an adapter outside aggregation", () => {
+    const inactiveAdapter = { ...adapter, selected: false };
+    mocks.useEngineState.mockReturnValue({
+      ...engineState(),
+      adapters: [inactiveAdapter],
+      selected: [],
+      totalWeight: 0,
+    });
+    const onNavigate = vi.fn();
+    render(<HomePage onNavigate={onNavigate} />);
+
+    const nameButton = screen.getByRole("button", { name: "View active connections for Ethernet" }) as HTMLButtonElement;
+    expect(nameButton.disabled).toBe(true);
+    fireEvent.click(nameButton);
+    fireEvent.click(screen.getByRole("article"));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps adapter controls from triggering connection navigation", () => {
+    const onNavigate = vi.fn();
+    render(<HomePage onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Disable Ethernet" }));
+    fireEvent.click(screen.getByRole("button", { name: "Increase Ethernet Weight" }));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/frontend/src/pages/HomePage.tsx
+++ b/desktop/frontend/src/pages/HomePage.tsx
@@ -40,7 +40,7 @@ const formatBytes = (value: number) => {
   return `${value} B`;
 };
 
-export function HomePage({ onNavigate }: { onNavigate?: (page: AppPage) => void }) {
+export function HomePage({ onNavigate }: { onNavigate?: (page: AppPage, adapterName?: string) => void }) {
   const { locale, t } = useI18n();
   const text = (zh: string, en: string) => locale === "en" ? en : zh;
   const [preflightDialog, setPreflightDialog] = useState<TunPreflightSnapshot | null>(null);
@@ -162,6 +162,7 @@ export function HomePage({ onNavigate }: { onNavigate?: (page: AppPage) => void 
               adapter={adapter}
               percentage={adapter.selected ? Math.round((adapter.weight / engine.totalWeight) * 100) || 0 : 0}
               disabled={engine.transitioning || engine.phase === "running"}
+              onOpenConnections={() => onNavigate?.("connections", adapter.name)}
               onSelectedChange={(checked) => engine.toggleAdapter(adapter.id, checked)}
               onWeightChange={(value) => engine.updateWeight(adapter.id, value)}
             />

--- a/desktop/frontend/src/pages/HomePage.tsx
+++ b/desktop/frontend/src/pages/HomePage.tsx
@@ -24,7 +24,7 @@ import {
   ShieldError20Regular,
   Warning20Regular,
 } from "@fluentui/react-icons";
-import { useEngineState } from "../state/useEngineState";
+import { useEngineState, type HomeAdapter } from "../state/useEngineState";
 import { EngineHero } from "../components/home/EngineHero";
 import { NetworkAdapterItem } from "../components/home/NetworkAdapterItem";
 import { RuntimeStatusBar } from "../components/home/RuntimeStatusBar";
@@ -40,7 +40,13 @@ const formatBytes = (value: number) => {
   return `${value} B`;
 };
 
-export function HomePage({ onNavigate }: { onNavigate?: (page: AppPage, adapterName?: string) => void }) {
+export function HomePage({
+  onNavigate,
+  onAdapterRuntimeChange,
+}: {
+  onNavigate?: (page: AppPage, adapterName?: string) => void;
+  onAdapterRuntimeChange?: (adapters: HomeAdapter[]) => void;
+}) {
   const { locale, t } = useI18n();
   const text = (zh: string, en: string) => locale === "en" ? en : zh;
   const [preflightDialog, setPreflightDialog] = useState<TunPreflightSnapshot | null>(null);
@@ -81,6 +87,7 @@ export function HomePage({ onNavigate }: { onNavigate?: (page: AppPage, adapterN
   }, []);
   useEffect(() => () => preflightResolver.current?.(false), []);
   const engine = useEngineState(notifyError, handleTunPreflight);
+  useEffect(() => onAdapterRuntimeChange?.(engine.adapters), [engine.adapters, onAdapterRuntimeChange]);
   const preflightIssues = preflightDialog?.issues ?? [];
   const blockerCount = preflightIssues.filter((issue) => issue.level === "blocker").length;
   const warningCount = preflightIssues.filter((issue) => issue.level === "warning").length;

--- a/desktop/frontend/src/pages/connectionGroups.test.ts
+++ b/desktop/frontend/src/pages/connectionGroups.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { groupConnectionsByAdapter } from "./connectionGroups";
+
+describe("groupConnectionsByAdapter", () => {
+  it("groups connections and orders adapters by combined live throughput", () => {
+    const groups = groupConnectionsByAdapter(
+      [
+        { id: 1, adapter: "Ethernet" },
+        { id: 2, adapter: "Wi-Fi" },
+        { id: 3, adapter: "Ethernet" },
+      ],
+      [
+        { id: "Ethernet", download_bps: 100, upload_bps: 50 },
+        { id: "Wi-Fi", download_bps: 600, upload_bps: 50 },
+      ],
+    );
+
+    expect(groups.map((group) => ({
+      adapter: group.adapter,
+      downloadBPS: group.downloadBPS,
+      uploadBPS: group.uploadBPS,
+      connectionIDs: group.connections.map((connection) => connection.id),
+    }))).toEqual([
+      { adapter: "Wi-Fi", downloadBPS: 600, uploadBPS: 50, connectionIDs: [2] },
+      { adapter: "Ethernet", downloadBPS: 100, uploadBPS: 50, connectionIDs: [1, 3] },
+    ]);
+  });
+});

--- a/desktop/frontend/src/pages/connectionGroups.test.ts
+++ b/desktop/frontend/src/pages/connectionGroups.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { groupConnectionsByAdapter } from "./connectionGroups";
 
 describe("groupConnectionsByAdapter", () => {
-  it("groups connections and orders adapters by combined live throughput", () => {
+  it("groups connections using the shared home adapter throughput", () => {
     const groups = groupConnectionsByAdapter(
       [
         { id: 1, adapter: "Ethernet" },
@@ -10,8 +10,8 @@ describe("groupConnectionsByAdapter", () => {
         { id: 3, adapter: "Ethernet" },
       ],
       [
-        { id: "Ethernet", download_bps: 100, upload_bps: 50 },
-        { id: "Wi-Fi", download_bps: 600, upload_bps: 50 },
+        { name: "Ethernet", downloadBPS: 100, uploadBPS: 50 },
+        { name: "Wi-Fi", downloadBPS: 600, uploadBPS: 50 },
       ],
     );
 

--- a/desktop/frontend/src/pages/connectionGroups.ts
+++ b/desktop/frontend/src/pages/connectionGroups.ts
@@ -3,9 +3,9 @@ type AdapterConnection = {
 };
 
 type AdapterThroughput = {
-  id: string;
-  download_bps: number;
-  upload_bps: number;
+  name: string;
+  downloadBPS: number;
+  uploadBPS: number;
 };
 
 export type AdapterConnectionGroup<T> = {
@@ -19,7 +19,7 @@ export const groupConnectionsByAdapter = <T extends AdapterConnection>(
   connections: readonly T[],
   adapters: readonly AdapterThroughput[],
 ): AdapterConnectionGroup<T>[] => {
-  const throughput = new Map(adapters.map((adapter) => [adapter.id, adapter]));
+  const throughput = new Map(adapters.map((adapter) => [adapter.name, adapter]));
   const groups = new Map<string, AdapterConnectionGroup<T>>();
   for (const connection of connections) {
     const adapter = connection.adapter?.trim() ?? "";
@@ -28,8 +28,8 @@ export const groupConnectionsByAdapter = <T extends AdapterConnection>(
       const speed = throughput.get(adapter);
       group = {
         adapter,
-        downloadBPS: speed?.download_bps ?? 0,
-        uploadBPS: speed?.upload_bps ?? 0,
+        downloadBPS: speed?.downloadBPS ?? 0,
+        uploadBPS: speed?.uploadBPS ?? 0,
         connections: [],
       };
       groups.set(adapter, group);

--- a/desktop/frontend/src/pages/connectionGroups.ts
+++ b/desktop/frontend/src/pages/connectionGroups.ts
@@ -1,0 +1,42 @@
+type AdapterConnection = {
+  adapter?: string;
+};
+
+type AdapterThroughput = {
+  id: string;
+  download_bps: number;
+  upload_bps: number;
+};
+
+export type AdapterConnectionGroup<T> = {
+  adapter: string;
+  downloadBPS: number;
+  uploadBPS: number;
+  connections: T[];
+};
+
+export const groupConnectionsByAdapter = <T extends AdapterConnection>(
+  connections: readonly T[],
+  adapters: readonly AdapterThroughput[],
+): AdapterConnectionGroup<T>[] => {
+  const throughput = new Map(adapters.map((adapter) => [adapter.id, adapter]));
+  const groups = new Map<string, AdapterConnectionGroup<T>>();
+  for (const connection of connections) {
+    const adapter = connection.adapter?.trim() ?? "";
+    let group = groups.get(adapter);
+    if (!group) {
+      const speed = throughput.get(adapter);
+      group = {
+        adapter,
+        downloadBPS: speed?.download_bps ?? 0,
+        uploadBPS: speed?.upload_bps ?? 0,
+        connections: [],
+      };
+      groups.set(adapter, group);
+    }
+    group.connections.push(connection);
+  }
+  return [...groups.values()].sort(
+    (left, right) => right.downloadBPS + right.uploadBPS - left.downloadBPS - left.uploadBPS,
+  );
+};

--- a/desktop/frontend/src/pages/connectionNavigation.test.ts
+++ b/desktop/frontend/src/pages/connectionNavigation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { advanceConnectionsNavigation } from "./connectionNavigation";
+
+describe("advanceConnectionsNavigation", () => {
+  it("keeps the clicked adapter separate from the connections search query", () => {
+    expect(advanceConnectionsNavigation({ adapter: "", revision: 2 }, "Ethernet 3"))
+      .toEqual({ adapter: "Ethernet 3", revision: 3 });
+  });
+
+  it("clears an adapter filter for a generic connections-page request", () => {
+    expect(advanceConnectionsNavigation({ adapter: "Wi-Fi", revision: 6 }))
+      .toEqual({ adapter: "", revision: 7 });
+  });
+});

--- a/desktop/frontend/src/pages/connectionNavigation.ts
+++ b/desktop/frontend/src/pages/connectionNavigation.ts
@@ -1,0 +1,12 @@
+export type ConnectionsNavigation = {
+  adapter: string;
+  revision: number;
+};
+
+export const advanceConnectionsNavigation = (
+  current: ConnectionsNavigation,
+  adapterName?: string,
+): ConnectionsNavigation => ({
+  adapter: adapterName ?? "",
+  revision: current.revision + 1,
+});

--- a/desktop/frontend/src/pages/connectionSort.test.ts
+++ b/desktop/frontend/src/pages/connectionSort.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { ConnectionView } from "../platform/services";
+import { sortConnections, type ConnectionSortKey } from "./connectionSort";
+
+const connections: ConnectionView[] = [
+  {
+    id: 1,
+    process: "Zulu.exe",
+    protocol: "tcp",
+    client: "127.0.0.1:51001",
+    target: "z.example:443",
+    domain: "z.example",
+    remote_ip: "203.0.113.30",
+    remote_port: "443",
+    adapter: "Wi-Fi",
+    outbound: "adapter",
+    outbound_detail: "Wi-Fi",
+    started_at: "2026-08-24T01:00:00Z",
+    bytes_up: 100,
+    bytes_down: 300,
+  },
+  {
+    id: 2,
+    process: "Alpha.exe",
+    protocol: "udp",
+    client: "127.0.0.1:51002",
+    target: "a.example:53",
+    domain: "a.example",
+    remote_ip: "203.0.113.10",
+    remote_port: "53",
+    adapter: "Ethernet",
+    outbound: "direct",
+    outbound_detail: "",
+    started_at: "2026-08-24T01:02:00Z",
+    bytes_up: 25,
+    bytes_down: 25,
+  },
+  {
+    id: 3,
+    process: "Mike.exe",
+    protocol: "tcp",
+    client: "127.0.0.1:51003",
+    target: "m.example:80",
+    domain: "m.example",
+    remote_ip: "203.0.113.20",
+    remote_port: "80",
+    adapter: "Ethernet",
+    outbound: "aggregation",
+    outbound_detail: "",
+    started_at: "2026-08-24T01:01:00Z",
+    bytes_up: 200,
+    bytes_down: 100,
+  },
+];
+
+describe("sortConnections", () => {
+  it.each<[ConnectionSortKey, number[], number[]]>([
+    ["process", [2, 3, 1], [1, 3, 2]],
+    ["destination", [2, 3, 1], [1, 3, 2]],
+    ["policy", [1, 3, 2], [2, 3, 1]],
+    ["traffic", [2, 3, 1], [1, 3, 2]],
+    ["duration", [2, 3, 1], [1, 3, 2]],
+  ])("sorts the %s column in both directions", (key, ascendingIDs, descendingIDs) => {
+    expect(sortConnections(connections, { key, direction: "ascending" }).map(({ id }) => id))
+      .toEqual(ascendingIDs);
+    expect(sortConnections(connections, { key, direction: "descending" }).map(({ id }) => id))
+      .toEqual(descendingIDs);
+  });
+
+  it("does not mutate the source list", () => {
+    sortConnections(connections, { key: "traffic", direction: "descending" });
+    expect(connections.map(({ id }) => id)).toEqual([1, 2, 3]);
+  });
+});

--- a/desktop/frontend/src/pages/connectionSort.ts
+++ b/desktop/frontend/src/pages/connectionSort.ts
@@ -1,0 +1,42 @@
+import type { ConnectionView } from "../platform/services";
+
+export type ConnectionSortKey = "process" | "destination" | "policy" | "traffic" | "duration";
+
+export type ConnectionSort = {
+  key: ConnectionSortKey;
+  direction: "ascending" | "descending";
+};
+
+export const sortConnections = (
+  connections: readonly ConnectionView[],
+  sort: ConnectionSort | null,
+): readonly ConnectionView[] => {
+  if (!sort) return connections;
+
+  const value = (connection: ConnectionView): string | number => {
+    switch (sort.key) {
+      case "process":
+        return connection.process || connection.domain || connection.remote_ip || connection.target || "";
+      case "destination":
+        return connection.domain || connection.remote_ip || connection.target || "";
+      case "policy":
+        return [connection.outbound, connection.outbound_detail, connection.adapter].filter(Boolean).join(" ");
+      case "traffic":
+        return connection.bytes_up + connection.bytes_down;
+      case "duration": {
+        const startedAt = Date.parse(connection.started_at);
+        return Number.isFinite(startedAt) ? -startedAt : Number.MAX_SAFE_INTEGER;
+      }
+    }
+  };
+
+  const direction = sort.direction === "ascending" ? 1 : -1;
+  return [...connections].sort((left, right) => {
+    const leftValue = value(left);
+    const rightValue = value(right);
+    const comparison = typeof leftValue === "number" && typeof rightValue === "number"
+      ? leftValue - rightValue
+      : String(leftValue).localeCompare(String(rightValue), undefined, { numeric: true, sensitivity: "base" });
+    return comparison * direction;
+  });
+};

--- a/desktop/frontend/src/pages/connectionView.test.ts
+++ b/desktop/frontend/src/pages/connectionView.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ConnectionView } from "../platform/services";
+import type { ConnectionSort } from "./connectionSort";
 import { selectConnections } from "./connectionView";
+
+const longestFirst: ConnectionSort = { key: "duration", direction: "descending" };
+const shortestFirst: ConnectionSort = { key: "duration", direction: "ascending" };
 
 const connection = (overrides: Partial<ConnectionView>): ConnectionView => ({
   id: 1,
@@ -26,18 +30,24 @@ describe("selectConnections", () => {
   ];
 
   it("filters by outbound policy and searchable egress detail", () => {
-    expect(selectConnections(connections, "", "adapter", "longest").map((item) => item.id)).toEqual([2]);
-    expect(selectConnections(connections, "热点", "all", "longest").map((item) => item.id)).toEqual([2]);
+    expect(selectConnections(connections, "", "adapter", "", longestFirst).map((item) => item.id)).toEqual([2]);
+    expect(selectConnections(connections, "热点", "all", "", longestFirst).map((item) => item.id)).toEqual([2]);
+  });
+
+  it("filters an adapter entry by exact adapter name", () => {
+    expect(selectConnections(connections, "", "all", "WLAN", longestFirst).map((item) => item.id))
+      .toEqual([1, 3, 2]);
+    expect(selectConnections(connections, "", "all", "LAN", longestFirst)).toEqual([]);
   });
 
   it("sorts active connections by longest or shortest duration", () => {
-    expect(selectConnections(connections, "", "all", "longest").map((item) => item.id)).toEqual([1, 3, 2]);
-    expect(selectConnections(connections, "", "all", "shortest").map((item) => item.id)).toEqual([2, 3, 1]);
+    expect(selectConnections(connections, "", "all", "", longestFirst).map((item) => item.id)).toEqual([1, 3, 2]);
+    expect(selectConnections(connections, "", "all", "", shortestFirst).map((item) => item.id)).toEqual([2, 3, 1]);
   });
 
   it("does not mutate the service snapshot order", () => {
     const original = connections.map((item) => item.id);
-    selectConnections(connections, "", "all", "shortest");
+    selectConnections(connections, "", "all", "", shortestFirst);
     expect(connections.map((item) => item.id)).toEqual(original);
   });
 });

--- a/desktop/frontend/src/pages/connectionView.ts
+++ b/desktop/frontend/src/pages/connectionView.ts
@@ -1,7 +1,7 @@
 import type { ConnectionView } from "../platform/services";
+import { sortConnections, type ConnectionSort } from "./connectionSort";
 
 export type ConnectionOutboundFilter = "all" | "aggregation" | "direct" | "adapter";
-export type ConnectionDurationSort = "longest" | "shortest";
 
 const searchableValues = (connection: ConnectionView) => [
   connection.process,
@@ -15,33 +15,19 @@ const searchableValues = (connection: ConnectionView) => [
   connection.protocol,
 ];
 
-const startedAt = (connection: ConnectionView) => {
-  const value = new Date(connection.started_at).getTime();
-  return Number.isFinite(value) ? value : null;
-};
-
 export const selectConnections = (
-  connections: ConnectionView[],
+  connections: readonly ConnectionView[],
   query: string,
   outboundFilter: ConnectionOutboundFilter,
-  durationSort: ConnectionDurationSort,
+  adapterFilter: string,
+  sort: ConnectionSort | null,
 ) => {
   const needle = query.trim().toLocaleLowerCase();
-  return connections
+  const adapter = adapterFilter.trim();
+  const filtered = connections
     .filter((connection) => outboundFilter === "all" || connection.outbound === outboundFilter)
+    .filter((connection) => !adapter || connection.adapter === adapter)
     .filter((connection) => !needle || searchableValues(connection)
-      .some((value) => value?.toLocaleLowerCase().includes(needle)))
-    .slice()
-    .sort((left, right) => {
-      const leftStartedAt = startedAt(left);
-      const rightStartedAt = startedAt(right);
-      if (leftStartedAt === null || rightStartedAt === null) {
-        if (leftStartedAt === rightStartedAt) return left.id - right.id;
-        return leftStartedAt === null ? 1 : -1;
-      }
-      const byStartedAt = durationSort === "longest"
-        ? leftStartedAt - rightStartedAt
-        : rightStartedAt - leftStartedAt;
-      return byStartedAt || left.id - right.id;
-    });
+      .some((value) => value?.toLocaleLowerCase().includes(needle)));
+  return sortConnections(filtered, sort);
 };

--- a/desktop/installer_layout_test.go
+++ b/desktop/installer_layout_test.go
@@ -542,11 +542,25 @@ func TestHomeEngineStatePersistsAcrossPageNavigation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	homeData, err := os.ReadFile("frontend/src/pages/HomePage.tsx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	connectionsData, err := os.ReadFile("frontend/src/pages/ConnectionsPage.tsx")
+	if err != nil {
+		t.Fatal(err)
+	}
 	appSource := string(appData)
 	shellSource := string(shellData)
+	homeSource := string(homeData)
+	connectionsSource := string(connectionsData)
 	for _, required := range []string{
 		`persistentPage="home"`,
-		`persistentChildren={<HomePage onNavigate={navigate} />}`,
+		`persistentChildren={(`,
+		`<HomePage`,
+		`onNavigate={navigate}`,
+		`onAdapterRuntimeChange={setConnectionAdapters}`,
+		`adapterRuntime={connectionAdapters}`,
 		`hidden={page !== persistentPage}`,
 		`page !== persistentPage ? (`,
 	} {
@@ -556,6 +570,13 @@ func TestHomeEngineStatePersistsAcrossPageNavigation(t *testing.T) {
 	}
 	if strings.Contains(appSource, `: <HomePage onNavigate={navigate} />}`) {
 		t.Fatal("HomePage is still conditionally mounted and will lose an in-flight engine transition")
+	}
+	if !strings.Contains(homeSource, `onAdapterRuntimeChange?.(engine.adapters)`) {
+		t.Fatal("HomePage does not propagate its existing adapter telemetry")
+	}
+	if strings.Contains(connectionsSource, `appServices.engine.snapshot()`) ||
+		strings.Contains(connectionsSource, `setAdapterRuntime`) {
+		t.Fatal("ConnectionsPage must reuse HomePage telemetry instead of sampling engine state")
 	}
 }
 


### PR DESCRIPTION
## Summary
- make participating adapter cards open Active Connections with an exact adapter filter and grouped live throughput
- keep the generic Active Connections entry flat and independent from adapter navigation
- preserve the upstream egress filter while sorting all five columns through one shared pure function

## Validation
- npm test: 8 test files, 29 tests passed
- npm run build
- go mod verify, go test ./..., and go vet ./... for engine and desktop
- gofmt check: 181 tracked Go files
- independent code review: no remaining Critical, Important, or Minor findings

## Packaging note
- Wails binding generation, frontend production build, Core build, and desktop executable build completed locally
- the local windows:package task reached the NSIS step but this machine does not have makensis installed; the repository CI installs NSIS before packaging