### PR TITLE
fix: repair leaks, races and compatibility issues from full audit

### DIFF
--- a/desktop/frontend/src/pages/AboutPage.tsx
+++ b/desktop/frontend/src/pages/AboutPage.tsx
@@ -145,6 +145,7 @@ export function AboutPage() {
     } catch (error) {
       notify(text("下载安装包失败", "Installer download failed"), String(error), "error");
       setDownloading(false);
+      setDownloadPercent(0);
     } finally {
       stopProgressPoll();
     }

--- a/desktop/frontend/src/pages/ConnectionsPage.tsx
+++ b/desktop/frontend/src/pages/ConnectionsPage.tsx
@@ -102,6 +102,9 @@ export function ConnectionsPage({
     setOutboundFilter("all");
   }, [adapterRevision, initialAdapter]);
 
+  const textRef = useRef(text);
+  textRef.current = text;
+
   const load = useCallback(async (manual = false) => {
     if (requestActive.current) return;
     requestActive.current = true;
@@ -110,14 +113,14 @@ export function ConnectionsPage({
       const next = await withServiceTimeout(
         appServices.engine.connections(),
         8_000,
-        text("读取活动连接", "Loading active connections"),
+        textRef.current("读取活动连接", "Loading active connections"),
       );
       pendingScrollTop.current = connectionListRef.current?.scrollTop ?? null;
       setSnapshot({ ...next, connections: next.connections ?? [] });
     } catch (error) {
       dispatchToast(
         <Toast>
-          <ToastTitle>{text("无法读取活动连接", "Unable to load active connections")}</ToastTitle>
+          <ToastTitle>{textRef.current("无法读取活动连接", "Unable to load active connections")}</ToastTitle>
           <ToastBody>{error instanceof Error ? error.message : String(error)}</ToastBody>
         </Toast>,
         { intent: "error", timeout: 4200 },
@@ -127,7 +130,7 @@ export function ConnectionsPage({
       setLoading(false);
       setRefreshing(false);
     }
-  }, [dispatchToast, text]);
+  }, [dispatchToast]);
 
   useEffect(() => {
     void load();

--- a/desktop/frontend/src/pages/HealthPage.tsx
+++ b/desktop/frontend/src/pages/HealthPage.tsx
@@ -228,15 +228,19 @@ export function HealthPage({
     setEngineRunning(isNATDetectionBlocked(enginePhase));
   }, [enginePhase]);
 
+  const loadRef = useRef(load);
+  loadRef.current = load;
+
   useEffect(() => {
     mounted.current = true;
-    void load();
+    // 通过 ref 调用最新的 load，使语言切换重建回调时不会重新触发整页加载。
+    void loadRef.current();
     return () => {
       mounted.current = false;
       diagnosticEpoch.current += 1;
       stopPoller.current?.();
     };
-  }, [load]);
+  }, []);
 
   const persistAdapters = useCallback((next: AdapterView[]) => {
     adaptersRef.current = next;
@@ -245,12 +249,12 @@ export function HealthPage({
     const settings = homeSettingsRef.current;
     const handle = adapterSaveQueue.enqueue(adapterSaveInput(settings.mode, settings.weighted, next));
     void handle.done.then((saved) => {
-      if (!adapterSaveQueue.isCurrent(handle.revision)) return;
+      if (!mounted.current || !adapterSaveQueue.isCurrent(handle.revision)) return;
       const authoritative = saved ?? next;
       adaptersRef.current = authoritative;
       setAdapters(authoritative);
     }).catch((error) => {
-      if (!adapterSaveQueue.isCurrent(handle.revision)) return;
+      if (!mounted.current || !adapterSaveQueue.isCurrent(handle.revision)) return;
       notify(text("未能同步网卡选择", "Unable to sync adapter selection"), error instanceof Error ? error.message : String(error));
       void load();
     });
@@ -295,12 +299,15 @@ export function HealthPage({
         state: "running", run_id: "browser-fixture", target_ip: "223.5.5.5",
         total: selected.length, completed: 0, results: [], started_at: new Date().toISOString(),
       });
-      window.setTimeout(() => setSnapshot({
-        state: "completed", run_id: "browser-fixture", target_ip: "223.5.5.5",
-        total: selected.length, completed: selected.length,
-        results: selected.map(previewResult), started_at: new Date(Date.now() - 1500).toISOString(),
-        completed_at: new Date().toISOString(),
-      }), 850);
+      window.setTimeout(() => {
+        if (!mounted.current) return;
+        setSnapshot({
+          state: "completed", run_id: "browser-fixture", target_ip: "223.5.5.5",
+          total: selected.length, completed: selected.length,
+          results: selected.map(previewResult), started_at: new Date(Date.now() - 1500).toISOString(),
+          completed_at: new Date().toISOString(),
+        });
+      }, 850);
       return;
     }
     try {

--- a/desktop/frontend/src/state/useEngineState.ts
+++ b/desktop/frontend/src/state/useEngineState.ts
@@ -166,11 +166,13 @@ export function useEngineState(
   const transition = phase === "starting" || phase === "stopping";
   const transitionRef = useRef(transition);
   const previewRef = useRef(preview);
+  const onErrorRef = useRef(onError);
   modeRef.current = mode;
   weightedRef.current = weighted;
   adaptersRef.current = adapters;
   transitionRef.current = transition;
   previewRef.current = preview;
+  onErrorRef.current = onError;
 
   const applySnapshot = useCallback((
     next: EngineSnapshot,
@@ -196,11 +198,11 @@ export function useEngineState(
     const compatibilityNotice = next.reason?.startsWith("提示：") === true;
     if ((nextPhase === "failed" || nextPhase === "degraded" || compatibilityNotice) && next.reason && next.reason !== lastRuntimeFailure.current) {
       lastRuntimeFailure.current = next.reason;
-      onError(next.reason);
+      onErrorRef.current(next.reason);
     } else if (nextPhase === "running" && !compatibilityNotice) {
       lastRuntimeFailure.current = "";
     }
-  }, [onError]);
+  }, []);
 
   const load = useCallback(async (showError = true) => {
     if (isBrowserPreview()) {
@@ -235,7 +237,7 @@ export function useEngineState(
       applySnapshot(nextSnapshot, false, requestEpoch);
     }).catch((error) => {
       if (showError) {
-        onError(error instanceof Error ? error.message : String(error), () => void load());
+        onErrorRef.current(error instanceof Error ? error.message : String(error), () => void load());
       }
     });
 
@@ -253,13 +255,13 @@ export function useEngineState(
       setPreview(false);
     } catch (error) {
       if (showError) {
-        onError(error instanceof Error ? error.message : String(error), () => void load());
+        onErrorRef.current(error instanceof Error ? error.message : String(error), () => void load());
       }
     } finally {
       if (mounted.current) setLoading(false);
     }
     void runtimeTask;
-  }, [applySnapshot, onError]);
+  }, [applySnapshot]);
 
   useEffect(() => {
     mounted.current = true;
@@ -302,12 +304,12 @@ export function useEngineState(
       adaptersRef.current = authoritative;
       setAdapters(authoritative);
     }).catch((error) => {
-      if (!adapterSaveQueue.isCurrent(handle.revision)) return;
-      onError(error instanceof Error ? error.message : String(error), () => void persistAdapters(next, nextMode, nextWeighted));
+      if (!mounted.current || !adapterSaveQueue.isCurrent(handle.revision)) return;
+      onErrorRef.current(error instanceof Error ? error.message : String(error), () => void persistAdapters(next, nextMode, nextWeighted));
       void load(false);
     });
     return handle.done;
-  }, [load, onError, preview]);
+  }, [load, preview]);
 
   const setMode = useCallback((nextMode: EngineMode) => {
     setModeState(nextMode);
@@ -349,11 +351,11 @@ export function useEngineState(
         }
       }
     } catch (error) {
-      onError(error instanceof Error ? error.message : String(error), () => void refreshAdapters());
+      onErrorRef.current(error instanceof Error ? error.message : String(error), () => void refreshAdapters());
     } finally {
       if (mounted.current) setRefreshing(false);
     }
-  }, [onError, preview]);
+  }, [preview]);
 
   const toggleEngine = useCallback(async () => {
     if (transition || operationActive.current) return;

--- a/desktop/frontend/src/theme/appearance.store.tsx
+++ b/desktop/frontend/src/theme/appearance.store.tsx
@@ -142,17 +142,16 @@ export function AppearanceProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     applyDocumentTokens(settings, resolvedMode, accent);
-    if (hydrated) {
-      void appearancePersistence.save(settings)
-        .then(() => {
-          setPersistenceError(undefined);
-        })
-        .catch((error) => {
-          const message = error instanceof Error ? error.message : String(error);
-          setPersistenceError(message);
-          console.error("Unable to save appearance settings", error);
-        });
-    }
+    if (!hydrated) return;
+    void appearancePersistence.save(settings)
+      .then(() => {
+        setPersistenceError(undefined);
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        setPersistenceError(message);
+        console.error("Unable to save appearance settings", error);
+      });
     desktopPlatform
       .setWindowAppearance({ material: settings.material, mode: resolvedMode, accent })
       .then(setNativeResult);

--- a/desktop/internal/engineclient/client.go
+++ b/desktop/internal/engineclient/client.go
@@ -93,6 +93,8 @@ type Client struct {
 	normalLauncher   coreLauncher
 	elevatedLauncher coreLauncher
 	events           chan Event
+	done             chan struct{}
+	closed           atomic.Bool
 	lastLaunch       LaunchReport
 }
 
@@ -122,11 +124,30 @@ func newClient(normal, elevated coreLauncher) *Client {
 		normalLauncher:   normal,
 		elevatedLauncher: elevated,
 		events:           make(chan Event, 64),
+		done:             make(chan struct{}),
 	}
 }
 
 func (c *Client) Events() <-chan Event {
 	return c.events
+}
+
+// Done closes when the client is permanently shut down. Event consumers
+// select on it so they can exit even though events itself is never closed
+// (readLoop goroutines from old sessions may still try to deliver to it).
+func (c *Client) Done() <-chan struct{} {
+	return c.done
+}
+
+// Close permanently shuts the client down and unblocks event consumers.
+// Kill alone is not terminal because the client is reused across Core
+// restarts (engine stop/start, privilege switching, WFP repair).
+func (c *Client) Close() {
+	if !c.closed.CompareAndSwap(false, true) {
+		return
+	}
+	c.Kill()
+	close(c.done)
 }
 
 func (c *Client) ExecutablePath() string {
@@ -160,6 +181,9 @@ func (c *Client) EnsureElevated(ctx context.Context) (Hello, error) {
 }
 
 func (c *Client) ensure(ctx context.Context, requireElevated bool) (Hello, error) {
+	if c.closed.Load() {
+		return Hello{}, errors.New("聚合核心客户端已关闭")
+	}
 	select {
 	case c.startGate <- struct{}{}:
 		defer func() { <-c.startGate }()

--- a/desktop/internal/engineclient/service_windows.go
+++ b/desktop/internal/engineclient/service_windows.go
@@ -151,6 +151,8 @@ func connectCoreServicePipe(ctx context.Context, expectedPID int) (*os.File, err
 		return nil, err
 	}
 	var handle windows.Handle
+	retryTimer := time.NewTimer(40 * time.Millisecond)
+	defer retryTimer.Stop()
 	for {
 		handle, err = windows.CreateFile(
 			name,
@@ -170,7 +172,8 @@ func connectCoreServicePipe(ctx context.Context, expectedPID int) (*os.File, err
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(40 * time.Millisecond):
+		case <-retryTimer.C:
+			retryTimer.Reset(40 * time.Millisecond)
 		}
 	}
 

--- a/desktop/internal/platform/wails/desktop.go
+++ b/desktop/internal/platform/wails/desktop.go
@@ -191,5 +191,7 @@ func (d *DesktopHost) OpenDirectory(path string) error {
 	if err := command.Start(); err != nil {
 		return fmt.Errorf("打开目录失败：%w", err)
 	}
+	// 打开目录的进程无需等待结果；显式释放避免进程资源滞留到 GC。
+	_ = command.Process.Release()
 	return nil
 }

--- a/desktop/internal/services/atomic_file.go
+++ b/desktop/internal/services/atomic_file.go
@@ -16,8 +16,11 @@ func atomicWriteFile(path string, data []byte, permission os.FileMode) error {
 		return err
 	}
 	committed := false
+	closed := false
 	defer func() {
-		_ = file.Close()
+		if !closed {
+			_ = file.Close()
+		}
 		if !committed {
 			_ = os.Remove(temporary)
 		}
@@ -31,6 +34,7 @@ func atomicWriteFile(path string, data []byte, permission os.FileMode) error {
 	if err := file.Close(); err != nil {
 		return err
 	}
+	closed = true
 	if err := os.Rename(temporary, path); err != nil {
 		return fmt.Errorf("replace %s: %w", filepath.Base(path), err)
 	}

--- a/desktop/internal/services/blocked_domains.go
+++ b/desktop/internal/services/blocked_domains.go
@@ -45,12 +45,20 @@ func NewBlockedDomainService(settings *SettingsService) *BlockedDomainService {
 	return service
 }
 
+type purgedDomain struct {
+	adapter string
+	domain  string
+	expiry  float64
+}
+
 func (s *BlockedDomainService) List() (BlockedDomainSnapshot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	changed := s.purgeExpiredLocked()
-	if changed {
-		_ = s.saveLocked()
+	purged := s.purgeExpiredLocked()
+	if len(purged) > 0 {
+		if err := s.saveLocked(); err != nil {
+			s.restorePurgedLocked(purged)
+		}
 	}
 	preferences := s.settings.Get()
 	snapshot := BlockedDomainSnapshot{
@@ -166,24 +174,33 @@ func (s *BlockedDomainService) load() error {
 	return nil
 }
 
-func (s *BlockedDomainService) purgeExpiredLocked() bool {
+func (s *BlockedDomainService) purgeExpiredLocked() []purgedDomain {
 	if !s.settings.Get().BlockedDomainExpiry {
-		return false
+		return nil
 	}
 	now := float64(s.now().Unix())
-	changed := false
+	var purged []purgedDomain
 	for adapter, domains := range s.entries {
 		for domain, expiry := range domains {
 			if expiry <= now {
 				delete(domains, domain)
-				changed = true
+				purged = append(purged, purgedDomain{adapter: adapter, domain: domain, expiry: expiry})
 			}
 		}
 		if len(domains) == 0 {
 			delete(s.entries, adapter)
 		}
 	}
-	return changed
+	return purged
+}
+
+func (s *BlockedDomainService) restorePurgedLocked(purged []purgedDomain) {
+	for _, entry := range purged {
+		if s.entries[entry.adapter] == nil {
+			s.entries[entry.adapter] = map[string]float64{}
+		}
+		s.entries[entry.adapter][entry.domain] = entry.expiry
+	}
 }
 
 func (s *BlockedDomainService) saveLocked() error {

--- a/desktop/internal/services/engine.go
+++ b/desktop/internal/services/engine.go
@@ -249,7 +249,15 @@ func newEngineService(
 }
 
 func (s *EngineService) consumeCoreEvents() {
-	for event := range s.client.Events() {
+	events := s.client.Events()
+	done := s.client.Done()
+	for {
+		var event engineclient.Event
+		select {
+		case event = <-events:
+		case <-done:
+			return
+		}
 		switch event.Name {
 		case "dns.fallback_required":
 			var fallback dnsFallbackEvent
@@ -1134,6 +1142,7 @@ func (s *EngineService) Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	s.client.Shutdown(ctx)
+	s.client.Close()
 }
 
 func errorText(err error) string {

--- a/desktop/internal/services/settings.go
+++ b/desktop/internal/services/settings.go
@@ -126,8 +126,9 @@ func settingsDirectory() string {
 
 func (s *SettingsService) Get() AppSettings {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
 	result := cloneSettings(s.settings)
+	s.mu.RUnlock()
+	// 注册表查询可能因系统负载或安全软件变慢，放到锁外避免阻塞写入。
 	if enabled, err := s.autostartEnabled(); err == nil {
 		result.Autostart = enabled
 		if !enabled {

--- a/desktop/internal/services/tun_config.go
+++ b/desktop/internal/services/tun_config.go
@@ -256,6 +256,7 @@ func writeSingBoxConfigWithOptions(
 		return "", "", clashAPIConfig{}, fmt.Errorf("写入 TUN 配置失败：%w", err)
 	}
 	if err := os.Rename(temporary, path); err != nil {
+		_ = os.Remove(temporary)
 		return "", "", clashAPIConfig{}, fmt.Errorf("提交 TUN 配置失败：%w", err)
 	}
 	return singBox, path, clashAPI, nil

--- a/desktop/internal/services/updater_windows.go
+++ b/desktop/internal/services/updater_windows.go
@@ -61,6 +61,10 @@ func validateDownloadedInstallerPath(installerPath string) (string, error) {
 	if err != nil {
 		return "", errors.New("下载的安装包路径无效")
 	}
+	// 路径会被写入批处理脚本执行，拒绝可能被 cmd.exe 解释的元字符。
+	if strings.ContainsAny(absolute, "%&|<>^\"") {
+		return "", errors.New("下载的安装包路径包含不安全字符")
+	}
 	info, err := os.Stat(absolute)
 	if err != nil || info.IsDir() || !installerNamePattern.MatchString(filepath.Base(absolute)) {
 		return "", errors.New("下载的安装包不存在或名称无效")

--- a/engine/cmd/hypomux-engine/main.go
+++ b/engine/cmd/hypomux-engine/main.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -128,8 +130,10 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 }
 
 func runServer(input io.Reader, output, stderr io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 	engineServer := server.New(input, output, runtimeServerMetadata())
-	if err := engineServer.Run(context.Background()); err != nil {
+	if err := engineServer.Run(ctx); err != nil {
 		fmt.Fprintf(stderr, "hypomux-engine: %v\n", err)
 		return 1
 	}
@@ -154,6 +158,10 @@ func runtimeServerMetadata() server.Metadata {
 	if err != nil {
 		return metadata
 	}
-	metadata.TunExecutable = filepath.Join(filepath.Dir(executable), "sing-box.exe")
+	tunName := "sing-box"
+	if runtime.GOOS == "windows" {
+		tunName += ".exe"
+	}
+	metadata.TunExecutable = filepath.Join(filepath.Dir(executable), tunName)
 	return metadata
 }

--- a/engine/cmd/hypomux-engine/service_policy_windows_test.go
+++ b/engine/cmd/hypomux-engine/service_policy_windows_test.go
@@ -38,8 +38,18 @@ func TestBuildCoreServicePolicyPinsInstalledDesktopAndSidecar(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.EqualFold(policy.DesktopPath, desktopPath) ||
-		!strings.EqualFold(policy.TunExecutable, tunPath) {
+	// 临时目录可能包含 8.3 短名（如 ADMINI~1），而策略路径经
+	// GetFinalPathNameByHandle 规范化为长名，期望值必须同样规范化。
+	expectedDesktop, err := canonicalRegularFile(desktopPath, "expected desktop executable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedTun, err := canonicalRegularFile(tunPath, "expected sing-box executable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(policy.DesktopPath, expectedDesktop) ||
+		!strings.EqualFold(policy.TunExecutable, expectedTun) {
 		t.Fatalf("unexpected policy paths: %#v", policy)
 	}
 	if err := fileintegrity.VerifySHA256(policy.DesktopPath, policy.DesktopSHA256); err != nil {

--- a/engine/internal/diagnostic/diagnostic.go
+++ b/engine/internal/diagnostic/diagnostic.go
@@ -90,7 +90,18 @@ func Run(ctx context.Context, config Config) Result {
 		}
 
 		base.Sent++
-		probe := icmp.Probe(source, target, probePayload, config.Timeout)
+		probeTimeout := config.Timeout
+		if deadline, ok := ctx.Deadline(); ok {
+			if remaining := time.Until(deadline); remaining < probeTimeout {
+				probeTimeout = remaining
+			}
+		}
+		if probeTimeout <= 0 {
+			result := summarize(base, rtts, base.Sent, bindError, bindErrorCode)
+			result.Note = "cancelled"
+			return result
+		}
+		probe := icmp.Probe(source, target, probePayload, probeTimeout)
 		if probe.success {
 			rtts = append(rtts, probe.roundTripTimeMS)
 		}

--- a/engine/internal/proxy/registry.go
+++ b/engine/internal/proxy/registry.go
@@ -87,6 +87,7 @@ type connection struct {
 	adapter   string
 	counters  atomic.Pointer[adapterCounters]
 	direct    atomic.Bool
+	finished  atomic.Bool
 	bytesUp   atomic.Uint64
 	bytesDown atomic.Uint64
 }
@@ -216,6 +217,10 @@ func (r *registry) AddDown(session *connection, amount uint64) {
 }
 
 func (r *registry) Finish(session *connection) {
+	// 防止重复 Finish 导致活跃连接计数下溢为巨大值。
+	if !session.finished.CompareAndSwap(false, true) {
+		return
+	}
 	r.mu.Lock()
 	delete(r.connections, session.id)
 	r.mu.Unlock()

--- a/engine/internal/proxy/server.go
+++ b/engine/internal/proxy/server.go
@@ -159,6 +159,7 @@ func (s *Server) startChannelListeners() (Endpoints, error) {
 				_ = opened.Close()
 			}
 			s.cancel()
+			s.resolver = nil
 			return Endpoints{}, fmt.Errorf("listen channel %q: %w", channel.Name, err)
 		}
 		listeners = append(listeners, listener)
@@ -252,8 +253,11 @@ func (s *Server) Snapshot(includeConnections bool) TelemetrySnapshot {
 			},
 		)
 	}
-	if s.resolver != nil {
-		status := s.resolver.Status()
+	s.mu.RLock()
+	resolver := s.resolver
+	s.mu.RUnlock()
+	if resolver != nil {
+		status := resolver.Status()
 		result.DNS = &status
 	}
 	return result

--- a/engine/internal/proxy/udp.go
+++ b/engine/internal/proxy/udp.go
@@ -459,8 +459,10 @@ func parseSOCKSUDPPacket(payload []byte) (socksUDPPacket, bool) {
 			return socksUDPPacket{}, false
 		}
 		ip = net.IP(payload[4:20])
-		if ip.To4() != nil {
-			return socksUDPPacket{}, false
+		// 部分客户端会用 IPv6 格式携带 IPv4 映射地址（::ffff:a.b.c.d），
+		// 按 IPv4 处理而不是拒绝，保持与回复编码（IPv4 用 ATYP=1）对称。
+		if mapped := ip.To4(); mapped != nil {
+			ip = mapped
 		}
 		portOffset = 20
 	default:

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -82,14 +82,39 @@ func (s *Server) Run(ctx context.Context) error {
 	scanner := bufio.NewScanner(s.input)
 	scanner.Buffer(make([]byte, 64*1024), protocol.MaxMessageBytes)
 
-	for scanner.Scan() {
+	// scanner.Scan 会阻塞在对端的下一次写入/关闭上，放在独立 goroutine 里
+	// 才能让 ctx 取消（如信号退出）立即结束 Run，而不是等到输入流关闭。
+	lines := make(chan []byte)
+	scanErr := make(chan error, 1)
+	go func() {
+		for scanner.Scan() {
+			line := append([]byte(nil), scanner.Bytes()...)
+			select {
+			case lines <- line:
+			case <-ctx.Done():
+				return
+			}
+		}
+		scanErr <- scanner.Err()
+		close(lines)
+	}()
+
+	for {
+		var raw []byte
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
+		case received, ok := <-lines:
+			if !ok {
+				if err := <-scanErr; err != nil {
+					return fmt.Errorf("read request: %w", err)
+				}
+				return nil
+			}
+			raw = received
 		}
 
-		line := bytes.TrimSpace(scanner.Bytes())
+		line := bytes.TrimSpace(raw)
 		if len(line) == 0 {
 			continue
 		}
@@ -121,11 +146,6 @@ func (s *Server) Run(ctx context.Context) error {
 			return nil
 		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read request: %w", err)
-	}
-	return nil
 }
 
 func (s *Server) handle(ctx context.Context, line []byte) (protocol.Response, bool) {


### PR DESCRIPTION
# HypoMux 全项目 Bug 与兼容性修复报告

- **日期**：2026-08-31
- **范围**：`engine/`（Go 聚合引擎）、`desktop/`（Wails 桌面层 + Go 服务）、`desktop/frontend/`（React 前端）
- **方法**：三路并行深度代码审查（引擎 / 桌面层 / 前端）+ 构建验证（`go build` / `go vet` / `go test` / `tsc` / `vitest` / `vite build`）
- **结果**：确认并修复 **24** 项问题，另有 14 项审查发现经代码核实为误报或设计权衡（附理由），全部验证通过

---

## 一、修复清单

### 桌面层（desktop，Go）— 8 项

| # | 严重度 | 文件 | 问题 | 修复 |
|---|--------|------|------|------|
| D1 | 高 | `internal/services/engine.go`、`internal/engineclient/client.go` | `consumeCoreEvents` 对永不关闭的 events channel 做 `range`，应用退出时该 goroutine 永久泄漏 | `Client` 新增 `done` channel 与 `Close()`/`Done()` 方法；消费循环改为 `select` 监听事件与 `Done()`；`EngineService.Shutdown` 末尾调用 `Close()`；`ensure` 在关闭后拒绝重启核心 |
| D2 | 高→已缓解 | `internal/services/settings.go:127` | `Get()` 持有 `RLock` 期间调用 `autostartEnabled()` 做注册表 I/O，注册表访问变慢时会阻塞所有设置写入 | 锁内仅克隆设置，释放锁后再查询注册表 |
| D3 | 中 | `internal/services/atomic_file.go` | 显式 `Close()` 成功后 defer 再次 Close（重复关闭） | 增加 `closed` 标志，避免重复关闭 |
| D4 | 中 | `internal/platform/wails/desktop.go:181` | `OpenDirectory` 调用 `command.Start()` 后未 `Release()`，进程资源滞留到 GC | 启动成功后显式 `command.Process.Release()` |
| D5 | 中 | `internal/engineclient/service_windows.go:170` | 管道重连循环每轮用 `time.After` 创建新定时器，提前退出时未到期定时器滞留 | 改用可复用的 `time.NewTimer` + `Reset`/`Stop` |
| D6 | 中 | `internal/services/tun_config.go:258` | TUN 配置 `os.Rename` 失败时 `.tmp` 临时文件残留 | 失败路径显式删除临时文件（与 `blocked_domains.saveLocked` 一致） |
| D7 | 中 | `internal/services/updater_windows.go` | 更新启动器是批处理脚本，安装包路径中若含 cmd 元字符（如 `%`、`&`）可能被 shell 解释 | `validateDownloadedInstallerPath` 增加元字符拒绝校验（`%&|<>^"`） |
| D8 | 中 | `internal/services/blocked_domains.go` | `List()` 清理过期条目后保存失败时错误被忽略，内存与磁盘不一致（重启后过期条目复活） | `purgeExpiredLocked` 返回被移除条目；保存失败时经 `restorePurgedLocked` 回滚 |

### 引擎层（engine，Go）— 9 项

| # | 严重度 | 文件 | 问题 | 修复 |
|---|--------|------|------|------|
| E1 | 中 | `internal/proxy/registry.go` | `Finish` 用 `Add(^uint64(0))` 递减，若被重复调用活跃连接计数会下溢为巨大值（遥测显示数十亿连接） | `connection` 增加 `finished atomic.Bool`，`Finish` 用 CAS 保证只生效一次 |
| E2 | 中 | `internal/server/server.go:80` | `Run` 循环中 `scanner.Scan()` 阻塞，context 取消（如信号退出）无法及时生效，进程挂起直到输入流关闭 | 读取移入独立 goroutine，主循环 `select` 同时监听 `ctx.Done()` 与行数据 |
| E3 | 中 | `internal/proxy/server.go:157` | channel listener 绑定失败时只取消 context，未将 `s.resolver` 置 nil（非 channel 路径有置 nil），后续可能访问已失效 resolver | 错误路径补 `s.resolver = nil` |
| E4 | 中 | `internal/diagnostic/diagnostic.go` | 带 deadline 的 context 取消后，最后一次探测仍等满完整超时 | 单次探测超时用 ctx 剩余时间钳制；剩余时间耗尽立即返回取消结果 |
| E5 | 中 | `internal/proxy/udp.go:462` | SOCKS5 UDP ASSOCIATE 中客户端用 ATYP=4（IPv6 格式）携带 IPv4 映射地址时数据包被静默丢弃 | 识别 `::ffff:a.b.c.d` 并转换为 IPv4 正常转发，与回复编码对称 |
| E6 | 低 | `internal/proxy/server.go:256` | `Snapshot` 无锁读取 `s.resolver`，与 `Stop` 并发时存在数据竞争（`DNSStatus` 有 RLock 而此处没有） | 用 `RLock` 取指针副本后再读取 |
| E7 | 低 | `cmd/hypomux-engine/main.go:132` | `serve` 模式传 `context.Background()`，Ctrl+C 无法触发优雅关闭（代理恢复、TUN 清理被跳过） | 改用 `signal.NotifyContext(os.Interrupt)` |
| E8 | 低 | `cmd/hypomux-engine/main.go:157` | TUN 可执行文件名在所有平台硬编码 `sing-box.exe`（engine 存在非 Windows 构建桩） | 按 `runtime.GOOS` 决定是否追加 `.exe` 后缀 |
| E9 | 高 | `cmd/hypomux-engine/service_policy_windows_test.go` | **预先存在的测试失败**：开启 8.3 短名的系统上 `t.TempDir()` 返回 `ADMINI~1` 短名路径，而策略路径经 `GetFinalPathNameByHandle` 规范化为长名，两者字符串不相等导致测试必然失败（本机实测复现） | 测试期望值同样经 `canonicalRegularFile` 规范化后再比较；生产代码不受影响（运行时校验两侧均规范化） |

### 前端（React/TypeScript）— 7 项

| # | 严重度 | 文件 | 问题 | 修复 |
|---|--------|------|------|------|
| F1 | 高 | `src/pages/HealthPage.tsx` | 挂载 effect 依赖 `[load]`，而 `load` 依赖 `text`（随 locale 变化）：切换语言触发整页数据重载 | 引入 `loadRef`，挂载 effect 只运行一次并通过 ref 调用最新 `load` |
| F2 | 中 | `src/pages/HealthPage.tsx:247` | `persistAdapters` 的 `.then/.catch` 未检查卸载状态，组件卸载后仍会 `setState` | 两处回调补 `mounted.current` 检查 |
| F3 | 中 | `src/pages/HealthPage.tsx:298` | 浏览器预览模式的诊断模拟定时器在组件卸载后仍执行 `setSnapshot` | 定时器回调补 `mounted.current` 守卫 |
| F4 | 中 | `src/pages/ConnectionsPage.tsx` | `load` 依赖 `text`，切换语言导致轮询注销重启 + 重复请求 | 引入 `textRef`，`load` 依赖数组移除 `text` |
| F5 | 中 | `src/theme/appearance.store.tsx:156` | hydration 完成前即把**默认**外观推送给原生窗口，冷启动时已保存的外观被短暂覆盖（视觉闪烁） | 原生窗口调用与持久化一样受 `hydrated` 守卫 |
| F6 | 中 | `src/state/useEngineState.ts` | `applySnapshot`/`load` 依赖 `onError`，父组件重建回调（语言切换等）导致两个遥测轮询被反复注销重启，产生数据间隙 | 引入 `onErrorRef`，相关 `useCallback` 全部移除 `onError` 依赖 |
| F7 | 低 | `src/pages/AboutPage.tsx` | 安装包下载失败后 `downloadPercent` 残留，UI 状态不一致 | 失败路径重置为 0 |

---

## 二、审查后确认无需修复的发现（附理由）

| 发现 | 结论 |
|------|------|
| DoH 竞速（`raceDoHBatch`）goroutine "泄漏" | **误报**：outcomes 为容量 `len(batch)` 的缓冲 channel，且调用方返回后立即 `cancel()` 批次 ctx，输家 goroutine 生命周期有界、必然退出 |
| UDP ASSOCIATE control reader goroutine 泄漏 | **误报**：`handleClient` 的 `defer client.Close()` 会中断 `io.Copy`，watcher 由 `associationDone` 保证退出，所有路径均闭合 |
| WFP `dnsSession.Close` 失败致 filter 残留 | **设计已覆盖**：会话使用 `fwpmSessionFlagDynamic`，BFE 在会话/进程结束时自动清理动态对象（含进程崩溃） |
| `stopProxyLocked` 持锁执行最长 25s 阻塞操作 | **设计权衡**：`lifecycleMu` 的目的就是串行化生命周期事务，锁外拆解会引入状态转换竞态，风险大于收益 |
| Updater `http.Client{}` 无 Timeout 字段 | **已有缓解**：所有请求均通过带超时的 `NewRequestWithContext` 发出；若设置 `Client.Timeout` 反而会截断合法的大体积长下载 |
| `support_log.appendLocked` 持锁做文件 I/O | 架构性问题，改异步写入队列风险高，维持现状 |
| `DiagnosticsService.RunNAT` reserved 标志 | 逻辑正确，仅维护性略脆弱 |
| `OnSecondInstanceLaunch` mainWindow 闭包 | 已有 `nil` 检查保护 |
| `sanitizeLogText` 用户路径正则 | 仅日志脱敏展示差异，无功能影响 |
| `versionKey` 版本段假设 | 已有正则限制最多 4 段 |
| `pathWithin` 未被生产代码调用 | 有完整测试覆盖的工具函数，保留 |
| `healthTable` backoff index | 分析证实不可触发 |
| `NATDetectionPage` 预览定时器 | 已有 `mounted.current` 守卫，无需改动 |
| `WallpaperLayer` CSS url() 注入面 | 输入仅来自 base64 data URL / 后端校验值，安全 |

---

## 三、验证结果

| 验证项 | 结果 |
|--------|------|
| `engine`：`go build ./...` / `go vet ./...` / `go test ./...` | ✅ 全部通过（10 个包） |
| `desktop`：`go build ./...` / `go vet ./...` / `go test ./...` | ✅ 全部通过（7 个包） |
| 前端 `tsc --noEmit` | ✅ 0 错误 |
| 前端 `vitest run` | ✅ 55/55 通过（15 个测试文件） |
| 前端 `vite build`（生产） | ✅ 构建成功 |
| 修复前基线 | 前端 20+ 个 tsc 错误均为 bindings 未生成所致；`service_policy` 测试失败为预先存在（8.3 短名兼容性） |

---

## 四、环境发现与处理

1. **本机无 Go 工具链** → 通过 winget 安装 Go 1.27.0（满足 go.mod 的 1.25/1.26 要求）。
2. **proxy.golang.org 不可达** → 已设置 `GOPROXY=https://goproxy.cn,direct`（`go env -w` 持久化）。
3. **系统禁止从 %TEMP% 执行二进制**（所有 `go test` 报 "Access is denied"）→ 已设置 `GOTMPDIR=D:\gotmp`。
4. **前端 Wails bindings 需 `wails3` CLI 生成**（`tsc && vite build` 存在先有鸡还是先有蛋的问题）→ 已安装与项目依赖一致的 `wails3 v3.0.0-alpha2.119`；生成命令：在 `desktop/` 下运行 `wails3 generate bindings -clean=true -ts -i`。

---

## 五、遗留建议（未改动，供后续参考）

- `SupportLogStore` 高频日志场景可考虑异步写入队列，避免磁盘 I/O 阻塞调用方。
- `RoutingPage.addRule` 的验证/追加存在理论竞态（验证后用户并发加规则），当前 UI 流程下不可触发，如需加固可将规则变更串行化。
- `stopProxyLocked` 若未来需要更快的状态查询响应，可评估将清理动作移出锁的两阶段方案（需谨慎设计状态机）。
